### PR TITLE
Use constexpr constants instead of defines.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,9 +28,9 @@ set(SPARROW_INCLUDE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/include)
 # ===========
 
 file(STRINGS "${SPARROW_INCLUDE_DIR}/sparrow/sparrow_version.hpp" sparrow_version_defines
-     REGEX "#define SPARROW_VERSION_(MAJOR|MINOR|PATCH)")
+     REGEX "constexpr int SPARROW_VERSION_(MAJOR|MINOR|PATCH)")
 foreach(ver ${sparrow_version_defines})
-    if(ver MATCHES "#define SPARROW_VERSION_(MAJOR|MINOR|PATCH) +([^ ]+)$")
+    if(ver MATCHES "constexpr int SPARROW_VERSION_(MAJOR|MINOR|PATCH) +([^ ]+)$")
         set(SPARROW_VERSION_${CMAKE_MATCH_1} "${CMAKE_MATCH_2}" CACHE INTERNAL "")
     endif()
 endforeach()

--- a/include/sparrow/sparrow_version.hpp
+++ b/include/sparrow/sparrow_version.hpp
@@ -14,7 +14,10 @@
 
 #pragma once
 
-#define SPARROW_VERSION_MAJOR 0
-#define SPARROW_VERSION_MINOR 0
-#define SPARROW_VERSION_PATCH 1
+namespace sparrow
+{
+    constexpr int SPARROW_VERSION_MAJOR = 0;
+    constexpr int SPARROW_VERSION_MINOR = 0;
+    constexpr int SPARROW_VERSION_PATCH = 1;
+}
 

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -15,12 +15,15 @@
 #define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
 #include "doctest/doctest.h"
 
-#include <format>
+#include <string>
 
 #include <sparrow/sparrow_version.hpp>
 
 TEST_CASE("version is readable")
 {
+    // TODO: once available on OSX, use `<format>` facility instead.
+    // We only try to make sure the version valeus are printable, whatever their type.
+    // AKA this is not written to be fancy but to force conversion to string.
     using namespace sparrow;
-    [[maybe_unused]] const std::string printable_version = std::format("sparrow version : {}.{}.{}", SPARROW_VERSION_MAJOR, SPARROW_VERSION_MINOR, SPARROW_VERSION_PATCH);
+    [[maybe_unused]] const std::string printable_version = std::string("sparrow version : ") + std::to_string(SPARROW_VERSION_MAJOR) + "." + std::to_string(SPARROW_VERSION_MINOR) "." std::to_string(SPARROW_VERSION_PATCH);
 }

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -25,5 +25,5 @@ TEST_CASE("version is readable")
     // We only try to make sure the version valeus are printable, whatever their type.
     // AKA this is not written to be fancy but to force conversion to string.
     using namespace sparrow;
-    [[maybe_unused]] const std::string printable_version = std::string("sparrow version : ") + std::to_string(SPARROW_VERSION_MAJOR) + "." + std::to_string(SPARROW_VERSION_MINOR) + "." std::to_string(SPARROW_VERSION_PATCH);
+    [[maybe_unused]] const std::string printable_version = std::string("sparrow version : ") + std::to_string(SPARROW_VERSION_MAJOR) + "." + std::to_string(SPARROW_VERSION_MINOR) + "." + std::to_string(SPARROW_VERSION_PATCH);
 }

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -16,3 +16,11 @@
 #include "doctest/doctest.h"
 
 #include <format>
+
+#include <sparrow/sparrow_version.hpp>
+
+TEST_CASE("version is readable")
+{
+    using namespace sparrow;
+    [[maybe_unused]] const std::string printable_version = std::format("sparrow version : {}.{}.{}", SPARROW_VERSION_MAJOR, SPARROW_VERSION_MINOR, SPARROW_VERSION_PATCH);
+}

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -25,5 +25,5 @@ TEST_CASE("version is readable")
     // We only try to make sure the version valeus are printable, whatever their type.
     // AKA this is not written to be fancy but to force conversion to string.
     using namespace sparrow;
-    [[maybe_unused]] const std::string printable_version = std::string("sparrow version : ") + std::to_string(SPARROW_VERSION_MAJOR) + "." + std::to_string(SPARROW_VERSION_MINOR) "." std::to_string(SPARROW_VERSION_PATCH);
+    [[maybe_unused]] const std::string printable_version = std::string("sparrow version : ") + std::to_string(SPARROW_VERSION_MAJOR) + "." + std::to_string(SPARROW_VERSION_MINOR) + "." std::to_string(SPARROW_VERSION_PATCH);
 }


### PR DESCRIPTION
This is both to avoid using the preprocessor in C++ in general, and to prepare for future usage of the library as a C++ module.