### PR TITLE
build: Require CMake 3.27

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-cmake_minimum_required(VERSION 3.28)
+cmake_minimum_required(VERSION 3.27)
 
 # This is better specified per target, but cmake keeps ignoring these language version
 # specification when building this project by itself, in particular the gnu extensions,


### PR DESCRIPTION
Requiring 3.28 is constraining for some build systems like vcpkg's which [currently uses CMake 3.27.1](https://github.com/microsoft/vcpkg/blame/7f9f0e44db287e8e67c0e888141bfa200ab45121/scripts/vcpkgTools.xml#L34).