### PR TITLE
Various Minor CI fixes

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -66,11 +66,11 @@ jobs:
 
     - name: Install
       working-directory: build
-      run: cmake --install .
+      run: cmake --install . --config ${{matrix.config.name}}
 
     - name: Build
       working-directory: build
-      run: cmake --build . --target test_sparrow_lib --parallel 8
+      run: cmake --build . --config ${{matrix.config.name}} --target test_sparrow_lib --parallel 8
 
     - name: Run tests
       working-directory: build

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -74,4 +74,4 @@ jobs:
 
     - name: Run tests
       working-directory: build
-      run: ./test/test_sparrow_lib
+      run: ctest

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -74,4 +74,4 @@ jobs:
 
     - name: Run tests
       working-directory: build
-      run: ctest
+      run: ctest -C ${{matrix.config.name}}

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -74,4 +74,4 @@ jobs:
 
     - name: Run tests
       working-directory: build
-      run: ctest -C ${{matrix.config.name}}
+      run: ctest -C ${{matrix.config.name}} --output-on-failure

--- a/.github/workflows/osx.yml
+++ b/.github/workflows/osx.yml
@@ -41,11 +41,11 @@ jobs:
 
     - name: Install
       working-directory: build
-      run: cmake --install .
+      run: cmake --install . --config ${{matrix.config.name}}
 
     - name: Build
       working-directory: build
-      run: cmake --build . --target test_sparrow_lib --parallel 8
+      run: cmake --build . --config ${{matrix.config.name}} --target test_sparrow_lib --parallel 8
 
     - name: Run tests
       working-directory: build

--- a/.github/workflows/osx.yml
+++ b/.github/workflows/osx.yml
@@ -13,7 +13,7 @@ defaults:
 jobs:
   build:
     runs-on: macos-${{ matrix.os }}
-    name: macos-${{ matrix.os }}-${{ matrix.config.name }}
+    name: ${{ matrix.os }}-${{ matrix.config.name }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/osx.yml
+++ b/.github/workflows/osx.yml
@@ -49,4 +49,4 @@ jobs:
 
     - name: Run tests
       working-directory: build
-      run: ctest -C ${{matrix.config.name}}
+      run: ctest -C ${{matrix.config.name}} --output-on-failure

--- a/.github/workflows/osx.yml
+++ b/.github/workflows/osx.yml
@@ -49,4 +49,4 @@ jobs:
 
     - name: Run tests
       working-directory: build
-      run: ./test/test_sparrow_lib
+      run: ctest

--- a/.github/workflows/osx.yml
+++ b/.github/workflows/osx.yml
@@ -49,4 +49,4 @@ jobs:
 
     - name: Run tests
       working-directory: build
-      run: ctest
+      run: ctest -C ${{matrix.config.name}}

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -13,7 +13,7 @@ defaults:
 jobs:
   build:
     runs-on: ${{ matrix.runs-on }}
-    name: ${{ matrix.sys.compiler }}-${{ matrix.config.name }}
+    name: ${{ matrix.sys.compiler }}-${{ matrix.build-system }}-${{ matrix.config.name }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -19,17 +19,23 @@ jobs:
       matrix:
         runs-on: [windows-latest]
         sys:
+        - {compiler: default}
         - {compiler: msvc}
         - {compiler: clang}
         config:
         - { name: Debug }
         - { name: Release }
+        build-system:
+        - "Visual Studio 17 2022"
+        - "Ninja"
 
     steps:
 
-    # - name: Setup MSVC
-    #   if: matrix.sys.compiler == 'msvc'
-    #   uses: ilammy/msvc-dev-cmd@v1
+    - name: Setup MSVC
+      if: matrix.sys.compiler == 'msvc' && matrix.build-system != 'Visual Studio 17 2022'
+      run: |
+        echo "CC=cl" >> $GITHUB_ENV
+        echo "CXX=cl" >> $GITHUB_ENV
 
     - name: Setup clang
       if: matrix.sys.compiler == 'clang'

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -67,4 +67,4 @@ jobs:
 
     - name: Run tests
       working-directory: build
-      run: ctest
+      run: ctest -C ${{matrix.config.name}}

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -67,4 +67,4 @@ jobs:
 
     - name: Run tests
       working-directory: build
-      run: ctest -C ${{matrix.config.name}}
+      run: ctest -C ${{matrix.config.name}} --output-on-failure

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -55,7 +55,7 @@ jobs:
           ninja
 
     - name: Configure using CMake
-      run: cmake -Bbuild -DCMAKE_BUILD_TYPE:STRING=${{matrix.config.name}} -DCMAKE_INSTALL_PREFIX=$CONDA_PREFIX -DBUILD_TESTS=ON -G Ninja
+      run: cmake -Bbuild -DCMAKE_BUILD_TYPE:STRING=${{matrix.config.name}} -DCMAKE_INSTALL_PREFIX=$CONDA_PREFIX -DBUILD_TESTS=ON -G ${{matrix.build-system}}
 
     - name: Install
       working-directory: build

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -67,4 +67,4 @@ jobs:
 
     - name: Run tests
       working-directory: build
-      run: ./test/test_sparrow_lib.exe
+      run: ctest

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -13,13 +13,13 @@ defaults:
 jobs:
   build:
     runs-on: ${{ matrix.runs-on }}
-    name: ${{ matrix.sys.compiler }}-${{ matrix.sys.config.name }}
+    name: ${{ matrix.sys.compiler }}-${{ matrix.config.name }}
     strategy:
       fail-fast: false
       matrix:
         runs-on: [windows-latest]
         sys:
-        - {compiler: default}
+        - {compiler: msvc}
         - {compiler: clang}
         config:
         - { name: Debug }
@@ -27,9 +27,9 @@ jobs:
 
     steps:
 
-    - name: Setup MSVC
-      if: matrix.sys.compiler == 'default'
-      uses: ilammy/msvc-dev-cmd@v1
+    # - name: Setup MSVC
+    #   if: matrix.sys.compiler == 'msvc'
+    #   uses: ilammy/msvc-dev-cmd@v1
 
     - name: Setup clang
       if: matrix.sys.compiler == 'clang'

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -59,11 +59,11 @@ jobs:
 
     - name: Install
       working-directory: build
-      run: cmake --install .
+      run: cmake --install . --config ${{matrix.config.name}}
 
     - name: Build
       working-directory: build
-      run: cmake --build . --target test_sparrow_lib --parallel 8
+      run: cmake --build . --config ${{matrix.config.name}} --target test_sparrow_lib --parallel 8
 
     - name: Run tests
       working-directory: build

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -33,9 +33,7 @@ jobs:
 
     - name: Setup MSVC
       if: matrix.sys.compiler == 'msvc' && matrix.build-system != 'Visual Studio 17 2022'
-      run: |
-        echo "CC=cl" >> $GITHUB_ENV
-        echo "CXX=cl" >> $GITHUB_ENV
+      uses: ilammy/msvc-dev-cmd@v1
 
     - name: Setup clang
       if: matrix.sys.compiler == 'clang'

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -67,4 +67,4 @@ jobs:
 
     - name: Run tests
       working-directory: build
-      run: ./test/test_sparrow_lib
+      run: ./test/test_sparrow_lib.exe

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -55,7 +55,7 @@ jobs:
           ninja
 
     - name: Configure using CMake
-      run: cmake -Bbuild -DCMAKE_BUILD_TYPE:STRING=${{matrix.config.name}} -DCMAKE_INSTALL_PREFIX=$CONDA_PREFIX -DBUILD_TESTS=ON -G ${{matrix.build-system}}
+      run: cmake -Bbuild -DCMAKE_BUILD_TYPE:STRING=${{matrix.config.name}} -DCMAKE_INSTALL_PREFIX=$CONDA_PREFIX -DBUILD_TESTS=ON -G "${{matrix.build-system}}"
 
     - name: Install
       working-directory: build

--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,7 @@
 
 # Ignore build directory
 /build/
+/build-*/
 
 # Ignore VSCODE specific options (unless we want to provide shortcuts to build and run, then delete these)
 /.vscode/

--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,6 @@
 
 # Ignore VSCODE specific options (unless we want to provide shortcuts to build and run, then delete these)
 /.vscode/
+
+# CTest directory
+/Testing/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -70,6 +70,7 @@ set_target_properties(sparrow PROPERTIES CMAKE_CXX_EXTENSIONS OFF)
 target_compile_features(sparrow INTERFACE cxx_std_20)
 
 if (BUILD_TESTS)
+    enable_testing()
     add_subdirectory(test)
 endif ()
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -14,11 +14,10 @@
 
 cmake_minimum_required(VERSION 3.8)
 
+enable_testing()
 
 if (CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
     project(sparrow-test CXX)
-
-    enable_testing()
 
     find_package(sparrowREQUIRED CONFIG)
     set(SPARROW_INCLUDE_DIR ${sparrow_INCLUDE_DIRS})
@@ -34,7 +33,7 @@ else()
     message(STATUS "Tests build type is ${CMAKE_BUILD_TYPE}")
 endif()
 
-set(SPARROW_TESTS
+set(SPARROW_TESTS_SOURCES
     main.cpp
     test_array_data.cpp
     test_buffer.cpp
@@ -43,8 +42,9 @@ set(SPARROW_TESTS
     test_layout.cpp
 )
 set(test_target "test_sparrow_lib")
-add_executable(${test_target} ${SPARROW_TESTS})
+add_executable(${test_target} ${SPARROW_TESTS_SOURCES})
 target_link_libraries(${test_target} PRIVATE sparrow doctest::doctest)
+add_test(NAME ${test_target} COMMAND ${test_target})
 
 # We do not use non-standard C++
 set_target_properties(${test_target} PROPERTIES CMAKE_CXX_EXTENSIONS OFF)


### PR DESCRIPTION
- using `ctest` to run the tests, which means we dont have to change the command executing tests every time we want to add a test executable or configuration;
- specifies `Debug` and `Release` configurations to be explicitly built and tested, to avoid issues because of CMake's inconsistency in the output of generators (some build-systems allow multiple configurations, so that removes any ambiguity) - also for installing;
- builds with both Ninja and VS on Windows, with msvc, mingw and clang;
- git-ignore some poentially generated directories
- fixed some ci runs names
