### PR TITLE
Add clang format

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,90 @@
+BasedOnStyle: Mozilla
+
+AccessModifierOffset: '-4'
+AlignAfterOpenBracket: BlockIndent
+AlignEscapedNewlines: Left
+AllowAllArgumentsOnNextLine: false
+AllowAllParametersOfDeclarationOnNextLine: false
+AllowShortBlocksOnASingleLine: false
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: false
+AllowShortIfStatementsOnASingleLine: false
+# Forbid one line lambdas because clang-format makes a weird split when
+# single instructions lambdas are too long.
+AllowShortLambdasOnASingleLine: Empty
+AllowShortLoopsOnASingleLine: false
+AlwaysBreakAfterDefinitionReturnType: None
+AlwaysBreakAfterReturnType: None
+AlwaysBreakTemplateDeclarations: Yes
+BinPackArguments: false
+BinPackParameters: false
+BreakBeforeBinaryOperators: NonAssignment
+BreakBeforeBraces: Allman
+BreakBeforeTernaryOperators: true
+BreakConstructorInitializers: BeforeComma
+BreakInheritanceList: AfterComma
+BreakStringLiterals: false
+ColumnLimit: '110'
+ConstructorInitializerIndentWidth: '4'
+ContinuationIndentWidth: '4'
+Cpp11BracedListStyle: true
+DerivePointerAlignment: false
+DisableFormat: false
+EmptyLineAfterAccessModifier: Always
+EmptyLineBeforeAccessModifier: Always
+ExperimentalAutoDetectBinPacking: true
+IncludeBlocks: Regroup
+IncludeCategories:
+- Regex: <[^.]+>
+  Priority: 1
+- Regex: <sparrow/.+>
+  Priority: 3
+- Regex: <.+>
+  Priority: 2
+- Regex: '"sparrow/.+"'
+  Priority: 4
+- Regex: '".+"'
+  Priority: 5
+IndentCaseLabels: true
+IndentWidth: '4'
+IndentWrappedFunctionNames: false
+InsertBraces: true
+InsertTrailingCommas: Wrapped
+KeepEmptyLinesAtTheStartOfBlocks: false
+LambdaBodyIndentation: Signature
+Language: Cpp
+MaxEmptyLinesToKeep: '2'
+NamespaceIndentation: All
+ObjCBlockIndentWidth: '4'
+ObjCSpaceAfterProperty: false
+ObjCSpaceBeforeProtocolList: false
+PackConstructorInitializers: Never
+PenaltyBreakAssignment: 100000
+PenaltyBreakBeforeFirstCallParameter: 0
+PenaltyBreakComment: 10
+PenaltyBreakOpenParenthesis: 0
+PenaltyBreakTemplateDeclaration: 0
+PenaltyExcessCharacter: 10
+PenaltyIndentedWhitespace: 0
+PenaltyReturnTypeOnItsOwnLine: 10
+PointerAlignment: Left
+QualifierAlignment: Custom  # Experimental
+QualifierOrder: [inline, static, constexpr, const, volatile, type]
+ReflowComments: true
+SeparateDefinitionBlocks: Always
+SortIncludes: CaseInsensitive
+SortUsingDeclarations: true
+SpaceAfterCStyleCast: true
+SpaceAfterTemplateKeyword: true
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeParens: ControlStatements
+SpaceInEmptyParentheses: false
+SpacesBeforeTrailingComments: '2'
+SpacesInAngles: false
+SpacesInCStyleCastParentheses: false
+SpacesInContainerLiterals: false
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+Standard: c++20
+TabWidth: '4'
+UseTab: Never

--- a/.github/workflows/analysis.yaml
+++ b/.github/workflows/analysis.yaml
@@ -1,0 +1,46 @@
+name: cpp-linter
+
+on: [push, pull_request]
+defaults:
+  run:
+    shell: bash -e -l {0}
+jobs:
+  build:
+    runs-on: ubuntu-latest
+        
+    steps:
+    - name: Install LLVM and Clang
+      uses: egor-tensin/setup-clang@v1
+      with:
+        version: 18
+        platform: x64
+    
+    - name: Checkout repository
+      uses: actions/checkout@v4
+
+    - name: Install Ninja
+      run: sudo apt install ninja-build -y
+
+    - name: Set conda environment
+      uses: mamba-org/setup-micromamba@main
+      with:
+        environment-name: myenv
+        environment-file: environment-dev.yml
+        init-shell: bash
+        cache-downloads: true
+
+    - name: Configure using CMake
+      run: cmake -G Ninja -Bbuild -DCMAKE_BUILD_TYPE:STRING=Debug -DCMAKE_INSTALL_PREFIX=$CONDA_PREFIX -DBUILD_TESTS=ON
+
+    - name: Run C++ analysis
+      uses: cpp-linter/cpp-linter-action@v2
+      id: linter
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        version: 18
+        # lines-changed-only: true
+        database: 'build'
+        style: 'file'  # Use .clang-format config file
+        tidy-checks: '-*' # disable clang-tidy checks.
+        step-summary: true

--- a/.github/workflows/analysis.yaml
+++ b/.github/workflows/analysis.yaml
@@ -18,9 +18,6 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v4
 
-    - name: Install Ninja
-      run: sudo apt install ninja-build -y
-
     - name: Set conda environment
       uses: mamba-org/setup-micromamba@main
       with:

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -12,7 +12,7 @@ defaults:
     shell: bash -e -l {0}
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     name: ${{ matrix.sys.compiler }}-${{ matrix.sys.version }}-${{ matrix.sys.stdlib }}-${{ matrix.config.name }}
     strategy:
       fail-fast: false
@@ -29,7 +29,6 @@ jobs:
         - { name: Release }
 
     steps:
-
 
     - name: Install GCC
       if: matrix.sys.compiler == 'gcc'
@@ -48,7 +47,6 @@ jobs:
     - name: Install the specified standard library for clang
       if: matrix.sys.compiler == 'clang'
       run: sudo apt install ${{matrix.sys.stdlib}}-dev -y
-
 
     - name: Checkout code
       uses: actions/checkout@v3

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,6 +43,15 @@ message(STATUS "Building sparrow v${${PROJECT_NAME}_VERSION}")
 
 OPTION(BUILD_TESTS "sparrow test suite" OFF)
 
+# Linter options
+# =============
+
+OPTION(ACTIVATE_LINTER "Create targets to run clang-format" OFF)
+
+if(ACTIVATE_LINTER)
+    include(cmake/clang-format.cmake)
+endif()
+
 # Dependencies
 # ============
 

--- a/cmake/clang-format.cmake
+++ b/cmake/clang-format.cmake
@@ -1,36 +1,84 @@
-find_program(CLANG_FORMAT clang-format)
+set(CLANG-FORMAT_MINIMUM_MAJOR_VERSION 18)
+
+function(get_clang_format_version clang_format_path)
+    set(CLANG_FORMAT_VERSION_OUTPUT "")
+    execute_process(
+        COMMAND ${clang_format_path} --version
+        OUTPUT_VARIABLE CLANG_FORMAT_VERSION_OUTPUT
+    )
+    string(REGEX MATCH "([0-9]+)\\.([0-9]+)\\.([0-9]+)" CLANG_FORMAT_VERSION_OUTPUT ${CLANG_FORMAT_VERSION_OUTPUT})
+    set(CLANG_FORMAT_MAJOR_VERSION ${CMAKE_MATCH_1} PARENT_SCOPE)
+    set(CLANG_FORMAT_MINOR_VERSION ${CMAKE_MATCH_2} PARENT_SCOPE)
+    set(CLANG_FORMAT_PATCH_VERSION ${CMAKE_MATCH_3} PARENT_SCOPE)
+endfunction()
+
+function(check_clang-format_version validator_result_var item)
+    set(${validator_result_var} FALSE PARENT_SCOPE)
+    get_clang_format_version(${item})
+    if (CLANG_FORMAT_MAJOR_VERSION LESS CLANG-FORMAT_MINIMUM_MAJOR_VERSION)
+        message(DEBUG "clang-format found at ${item} | version: ${CLANG_FORMAT_MAJOR_VERSION}.${CLANG_FORMAT_MINOR_VERSION}.${CLANG_FORMAT_PATCH_VERSION}")
+        message(DEBUG "but version is lower than ${CLANG-FORMAT_MINIMUM_MAJOR_VERSION}")
+        set(${validator_result_var} FALSE PARENT_SCOPE)
+    else()
+        set(${validator_result_var} TRUE PARENT_SCOPE)
+    endif()
+endfunction()
+
+function(print_clang_format_install_instructions)
+    message(STATUS "🛠️ Please install clang-format to enable code formatting")
+    message(STATUS "Can be installed via conda-forge: https://prefix.dev/channels/conda-forge/packages/clang-format")
+    if(UNIX)
+        if(APPLE)
+            message(STATUS "🍎 On MacOS, you can install clang-format with:")
+            message(STATUS "\t> brew install clang-format")
+        else()
+            message(STATUS "🐧 On Ubuntu, you can install clang-format with:")
+            message(STATUS "\t> sudo apt-get install clang-format")
+        endif()
+    elseif(WIN32)
+        message(STATUS "🪟 On Windows, you can install clang-format with:")
+        message(STATUS "\t> winget llvm")
+    endif()
+endfunction()
+
+find_program(CLANG_FORMAT clang-format
+             VALIDATOR check_clang-format_version)
 
 if(NOT CLANG_FORMAT)
-    message(WARNING "❗clang-format not found")
-    return()
+    message(WARNING "❗ clang-format not found")
+
+    print_clang_format_install_instructions()
+else()
+    get_clang_format_version(${CLANG_FORMAT})
+    message(STATUS "✅ clang-format (version: ${CLANG_FORMAT_MAJOR_VERSION}.${CLANG_FORMAT_MINOR_VERSION}.${CLANG_FORMAT_PATCH_VERSION}) found at ${CLANG_FORMAT}")
+
+    # list all files to format
+    set(
+        FORMAT_PATTERNS
+        include/*.hpp
+        test/*.cpp
+        test/*.hpp
+        CACHE STRING
+        "; separated patterns relative to the project source dir to format"
+    )
+
+    set(ALL_FILES_TO_FORMAT "")
+    foreach(PATTERN ${FORMAT_PATTERNS})
+        file(GLOB_RECURSE FILES_TO_FORMAT ${CMAKE_SOURCE_DIR}/${PATTERN})
+        list(APPEND ALL_FILES_TO_FORMAT ${FILES_TO_FORMAT})
+    endforeach()
+
+    add_custom_target(
+        clang-format
+        COMMAND ${CLANG_FORMAT} -i -style=file ${ALL_FILES_TO_FORMAT}
+        WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+        COMMENT "Running clang-format on all files"
+    )
+
+    add_custom_target(
+        clang-format_dry_run
+        COMMAND ${CLANG_FORMAT} --dry-run -style=file ${ALL_FILES_TO_FORMAT}
+        WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+        COMMENT "Running dry clang-format on all files"
+    )
 endif()
-
-# list all files to format
-set(
-    FORMAT_PATTERNS
-    include/*.hpp
-    test/*.cpp
-    test/*.hpp
-    CACHE STRING
-    "; separated patterns relative to the project source dir to format"
-)
-
-set(ALL_FILES_TO_FORMAT "")
-foreach(PATTERN ${FORMAT_PATTERNS})
-    file(GLOB_RECURSE FILES_TO_FORMAT ${CMAKE_SOURCE_DIR}/${PATTERN})
-    list(APPEND ALL_FILES_TO_FORMAT ${FILES_TO_FORMAT})
-endforeach()
-
-add_custom_target(
-    clang-format
-    COMMAND ${CLANG_FORMAT} -i -style=file ${ALL_FILES_TO_FORMAT}
-    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
-    COMMENT "Running clang-format on all files"
-)
-
-add_custom_target(
-    clang-format_dry_run
-    COMMAND ${CLANG_FORMAT} --dry-run -style=file ${ALL_FILES_TO_FORMAT}
-    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
-    COMMENT "Running dry clang-format on all files"
-)

--- a/cmake/clang-format.cmake
+++ b/cmake/clang-format.cmake
@@ -1,12 +1,11 @@
 find_program(CLANG_FORMAT clang-format)
 
 if(NOT CLANG_FORMAT)
-    message(WARNING "clang-format not found")
+    message(WARNING "❗clang-format not found")
     return()
 endif()
 
 # list all files to format
-
 set(
     FORMAT_PATTERNS
     include/*.hpp
@@ -22,23 +21,16 @@ foreach(PATTERN ${FORMAT_PATTERNS})
     list(APPEND ALL_FILES_TO_FORMAT ${FILES_TO_FORMAT})
 endforeach()
 
-string(REPLACE ";" "\n" FILES_TO_FORMAT "${ALL_FILES_TO_FORMAT}")
-
-# generate a txt file with one file path per line
-message(STATUS "Generating clang-format input file list")
-set(CLANG_FORMAT_INPUT_FILES ${CMAKE_BINARY_DIR}/clang-format_input_files.txt)
-file(WRITE ${CLANG_FORMAT_INPUT_FILES} ${FILES_TO_FORMAT})
-
 add_custom_target(
     clang-format
-    COMMAND ${CLANG_FORMAT} -i -style=file --files=${CLANG_FORMAT_INPUT_FILES}
+    COMMAND ${CLANG_FORMAT} -i -style=file ${ALL_FILES_TO_FORMAT}
     WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
     COMMENT "Running clang-format on all files"
 )
 
 add_custom_target(
     clang-format_dry_run
-    COMMAND ${CLANG_FORMAT} --dry-run -i -style=file --files=${CLANG_FORMAT_INPUT_FILES}
+    COMMAND ${CLANG_FORMAT} --dry-run -style=file ${ALL_FILES_TO_FORMAT}
     WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
     COMMENT "Running dry clang-format on all files"
 )

--- a/cmake/clang-format.cmake
+++ b/cmake/clang-format.cmake
@@ -1,0 +1,44 @@
+find_program(CLANG_FORMAT clang-format)
+
+if(NOT CLANG_FORMAT)
+    message(WARNING "clang-format not found")
+    return()
+endif()
+
+# list all files to format
+
+set(
+    FORMAT_PATTERNS
+    include/*.hpp
+    test/*.cpp
+    test/*.hpp
+    CACHE STRING
+    "; separated patterns relative to the project source dir to format"
+)
+
+set(ALL_FILES_TO_FORMAT "")
+foreach(PATTERN ${FORMAT_PATTERNS})
+    file(GLOB_RECURSE FILES_TO_FORMAT ${CMAKE_SOURCE_DIR}/${PATTERN})
+    list(APPEND ALL_FILES_TO_FORMAT ${FILES_TO_FORMAT})
+endforeach()
+
+string(REPLACE ";" "\n" FILES_TO_FORMAT "${ALL_FILES_TO_FORMAT}")
+
+# generate a txt file with one file path per line
+message(STATUS "Generating clang-format input file list")
+set(CLANG_FORMAT_INPUT_FILES ${CMAKE_BINARY_DIR}/clang-format_input_files.txt)
+file(WRITE ${CLANG_FORMAT_INPUT_FILES} ${FILES_TO_FORMAT})
+
+add_custom_target(
+    clang-format
+    COMMAND ${CLANG_FORMAT} -i -style=file --files=${CLANG_FORMAT_INPUT_FILES}
+    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+    COMMENT "Running clang-format on all files"
+)
+
+add_custom_target(
+    clang-format_dry_run
+    COMMAND ${CLANG_FORMAT} --dry-run -i -style=file --files=${CLANG_FORMAT_INPUT_FILES}
+    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+    COMMENT "Running dry clang-format on all files"
+)

--- a/include/sparrow/array_data.hpp
+++ b/include/sparrow/array_data.hpp
@@ -180,7 +180,7 @@ namespace sparrow
         self_type& operator=(U&& value);
 
         void swap(self_type& rhs);
-        
+
     private:
 
         void reset();
@@ -205,34 +205,26 @@ namespace sparrow
      * return reference proxies when it is dereferenced.
      */
     template <class L, bool is_const>
-    class layout_iterator : public iterator_base
-    <
-        layout_iterator<L, is_const>,
-        mpl::constify_t<typename L::value_type, is_const>,
-        typename L::iterator_tag,
-        std::conditional_t<is_const, const_reference_proxy<L>, reference_proxy<L>>
-    >
+    class layout_iterator : public iterator_base<
+                                layout_iterator<L, is_const>,
+                                mpl::constify_t<typename L::value_type, is_const>,
+                                typename L::iterator_tag,
+                                std::conditional_t<is_const, const_reference_proxy<L>, reference_proxy<L>>>
     {
     public:
 
         using self_type = layout_iterator<L, is_const>;
-        using base_type = iterator_base
-        <
+        using base_type = iterator_base<
             self_type,
             mpl::constify_t<typename L::value_type, is_const>,
             typename L::iterator_tag,
-            std::conditional_t<is_const, const_reference_proxy<L>, reference_proxy<L>>
-        >;
+            std::conditional_t<is_const, const_reference_proxy<L>, reference_proxy<L>>>;
         using reference = typename base_type::reference;
         using difference_type = typename base_type::difference_type;
 
-        using value_iterator = std::conditional_t<
-            is_const, typename L::const_value_iterator, typename L::value_iterator
-        >;
+        using value_iterator = std::conditional_t<is_const, typename L::const_value_iterator, typename L::value_iterator>;
 
-        using bitmap_iterator = std::conditional_t<
-            is_const, typename L::const_bitmap_iterator, typename L::bitmap_iterator
-        >;
+        using bitmap_iterator = std::conditional_t<is_const, typename L::const_bitmap_iterator, typename L::bitmap_iterator>;
 
         layout_iterator() noexcept = default;
         layout_iterator(value_iterator value_iter, bitmap_iterator bitmap_iter);
@@ -275,7 +267,6 @@ namespace sparrow
         const D1& dlhs = lhs.derived_cast();
         const D2& drhs = rhs.derived_cast();
         return (dlhs && drhs && (dlhs.value() == drhs.value())) || (!dlhs && !drhs);
-
     }
 
     template <class D, not_ref_proxy T>
@@ -400,7 +391,7 @@ namespace sparrow
 
     template <class L>
     template <std::convertible_to<typename L::inner_value_type> U>
-    auto reference_proxy<L>::operator=(const std::optional<U>& rhs) -> self_type& 
+    auto reference_proxy<L>::operator=(const std::optional<U>& rhs) -> self_type&
     {
         update(rhs);
         return *this;
@@ -408,7 +399,7 @@ namespace sparrow
 
     template <class L>
     template <std::convertible_to<typename L::inner_value_type> U>
-    auto reference_proxy<L>::operator=(std::optional<U>&& rhs) -> self_type& 
+    auto reference_proxy<L>::operator=(std::optional<U>&& rhs) -> self_type&
     {
         update(std::move(rhs));
         return *this;
@@ -487,10 +478,7 @@ namespace sparrow
      **********************************/
 
     template <class L, bool is_const>
-    layout_iterator<L, is_const>::layout_iterator(
-        value_iterator value_iter,
-        bitmap_iterator bitmap_iter
-    )
+    layout_iterator<L, is_const>::layout_iterator(value_iterator value_iter, bitmap_iterator bitmap_iter)
         : m_value_iter(value_iter)
         , m_bitmap_iter(bitmap_iter)
     {
@@ -541,4 +529,3 @@ namespace sparrow
         return m_value_iter < rhs.m_value_iter && m_bitmap_iter < rhs.m_bitmap_iter;
     }
 }
-

--- a/include/sparrow/buffer.hpp
+++ b/include/sparrow/buffer.hpp
@@ -19,8 +19,8 @@
 #include <concepts>
 #include <cstdint>
 
-#include "sparrow/mp_utils.hpp"
 #include "sparrow/iterator.hpp"
+#include "sparrow/mp_utils.hpp"
 
 namespace sparrow
 {
@@ -469,4 +469,3 @@ namespace sparrow
     {
     }
 }
-

--- a/include/sparrow/data_traits.hpp
+++ b/include/sparrow/data_traits.hpp
@@ -21,129 +21,128 @@
 namespace sparrow
 {
 
-    template<class T>
+    template <class T>
     struct common_native_types_traits
     {
         using value_type = T;
         using default_layout = fixed_size_layout<T>;
     };
 
-    template<>
+    template <>
     struct arrow_traits<std::nullopt_t>
     {
         static constexpr data_type type_id = data_type::NA;
         using value_type = std::nullopt_t;
-        using default_layout = fixed_size_layout<value_type>; // TODO: replace this by a special layout that's always empty
-
+        using default_layout = fixed_size_layout<value_type>;  // TODO: replace this by a special layout
+                                                               // that's always empty
     };
 
-    template<>
+    template <>
     struct arrow_traits<bool> : common_native_types_traits<bool>
     {
         static constexpr data_type type_id = data_type::BOOL;
     };
 
-    template<>
+    template <>
     struct arrow_traits<std::uint8_t> : common_native_types_traits<std::uint8_t>
     {
         static constexpr data_type type_id = data_type::UINT8;
     };
 
-    template<>
+    template <>
     struct arrow_traits<std::int8_t> : common_native_types_traits<std::int8_t>
     {
         static constexpr data_type type_id = data_type::INT8;
     };
 
-    template<>
+    template <>
     struct arrow_traits<std::uint16_t> : common_native_types_traits<std::uint16_t>
     {
         static constexpr data_type type_id = data_type::UINT16;
     };
 
-    template<>
+    template <>
     struct arrow_traits<std::int16_t> : common_native_types_traits<std::int16_t>
     {
         static constexpr data_type type_id = data_type::INT16;
     };
 
-    template<>
+    template <>
     struct arrow_traits<std::uint32_t> : common_native_types_traits<std::uint32_t>
     {
         static constexpr data_type type_id = data_type::UINT32;
     };
 
-    template<>
+    template <>
     struct arrow_traits<std::int32_t> : common_native_types_traits<std::int32_t>
     {
         static constexpr data_type type_id = data_type::INT32;
     };
 
-    template<>
+    template <>
     struct arrow_traits<std::uint64_t> : common_native_types_traits<std::uint64_t>
     {
         static constexpr data_type type_id = data_type::UINT64;
     };
 
-    template<>
+    template <>
     struct arrow_traits<std::int64_t> : common_native_types_traits<std::int64_t>
     {
         static constexpr data_type type_id = data_type::INT64;
     };
 
-    template<>
+    template <>
     struct arrow_traits<float16_t> : common_native_types_traits<float16_t>
     {
         static constexpr data_type type_id = data_type::HALF_FLOAT;
     };
 
-    template<>
+    template <>
     struct arrow_traits<float32_t> : common_native_types_traits<float32_t>
     {
         static constexpr data_type type_id = data_type::FLOAT;
     };
 
-    template<>
+    template <>
     struct arrow_traits<float64_t> : common_native_types_traits<float64_t>
     {
         static constexpr data_type type_id = data_type::DOUBLE;
     };
 
-    template<>
+    template <>
     struct arrow_traits<std::string>
     {
         static constexpr data_type type_id = data_type::STRING;
         using value_type = std::string;
-        using default_layout = variable_size_binary_layout<value_type, std::string_view, std::string_view>; // FIXME: this is incorrect, change when we have the right types
-
+        using default_layout = variable_size_binary_layout<value_type, std::string_view, std::string_view>;  // FIXME: this is incorrect, change when we have the right types
     };
 
-
-    template<>
+    template <>
     struct arrow_traits<std::vector<byte_t>>
     {
         static constexpr data_type type_id = data_type::STRING;
         using value_type = std::vector<byte_t>;
-        using default_layout = variable_size_binary_layout<value_type, std::span<byte_t>, std::span<byte_t>>; // FIXME: this is incorrect, change when we have the right types
-
+        using default_layout = variable_size_binary_layout<value_type, std::span<byte_t>, std::span<byte_t>>;  // FIXME: this is incorrect, change when we have the right types
     };
 
     namespace predicate
     {
 
-        struct {
-            template<class T>
+        struct
+        {
+            template <class T>
             consteval bool operator()(mpl::typelist<T>)
             {
                 return sparrow::is_arrow_base_type<T>;
             }
         } constexpr is_arrow_base_type;
 
-        struct {
-            template<class T>
+        struct
+        {
+            template <class T>
             consteval bool operator()(mpl::typelist<T>)
             {
-                return sparrow::is_arrow_traits< arrow_traits<T> >;
+                return sparrow::is_arrow_traits<arrow_traits<T>>;
             }
         } constexpr has_arrow_traits;
     }

--- a/include/sparrow/data_type.hpp
+++ b/include/sparrow/data_type.hpp
@@ -14,25 +14,27 @@
 
 #pragma once
 
-#include <cstdint>
 #include <climits>
+#include <cstdint>
+#include <optional>
 #include <string>
 #include <vector>
-#include <optional>
 
 #include "sparrow/mp_utils.hpp"
 
-// TODO: use exclusively `std::float16_t etc. once we switch to c++23, see https://en.cppreference.com/w/cpp/types/floating-point
+// TODO: use exclusively `std::float16_t etc. once we switch to c++23, see
+// https://en.cppreference.com/w/cpp/types/floating-point
 #if __cplusplus <= 202002L
-#   include "details/3rdparty/float16_t.hpp"
+#include "details/3rdparty/float16_t.hpp"
 #else
-#   include <stdfloat>
+#include <stdfloat>
 #endif
 
 
 namespace sparrow
 {
-// TODO: use exclusively `std::float16_t etc. once we switch to c++23, see https://en.cppreference.com/w/cpp/types/floating-point
+// TODO: use exclusively `std::float16_t etc. once we switch to c++23, see
+// https://en.cppreference.com/w/cpp/types/floating-point
 #if __cplusplus <= 202002L
     using float16_t = numeric::float16_t;
     using float32_t = float;
@@ -52,7 +54,8 @@ namespace sparrow
     static_assert(std::is_floating_point_v<float64_t>);
     static_assert(CHAR_BIT == 8);
 
-    using byte_t = std::byte; // For now we will use this to represent raw data TODO: evaluate later if it's the right choice, switch to char if not
+    using byte_t = std::byte;  // For now we will use this to represent raw data TODO: evaluate later if it's
+                               // the right choice, switch to char if not
 
 
     /// Runtime identifier of arrow data types, usually associated with raw bytes with the associated value.
@@ -83,31 +86,33 @@ namespace sparrow
 
     /// C++ types value representation types matching Arrow types.
     // NOTE: this needs to be in sync-order with `data_type`
-    using all_base_types_t = mpl::typelist
-    <
-        std::nullopt_t  // REVIEW: not sure about if we need to have this one? for representing NA? is this the right type?
-    ,   bool
-    ,   std::uint8_t
-    ,   std::int8_t
-    ,   std::uint16_t
-    ,   std::int16_t
-    ,   std::uint32_t
-    ,   std::int32_t
-    ,   std::uint64_t
-    ,   std::int64_t
-    ,   float16_t
-    ,   float32_t
-    ,   float64_t
-    ,   std::string
-    ,   std::vector<byte_t>
-    // TODO: add missing fundamental types here
-    >;
+    using all_base_types_t = mpl::typelist<
+        std::nullopt_t  // REVIEW: not sure about if we need to have this one? for representing NA? is this
+                        // the right type?
+        ,
+        bool,
+        std::uint8_t,
+        std::int8_t,
+        std::uint16_t,
+        std::int16_t,
+        std::uint32_t,
+        std::int32_t,
+        std::uint64_t,
+        std::int64_t,
+        float16_t,
+        float32_t,
+        float64_t,
+        std::string,
+        std::vector<byte_t>
+        // TODO: add missing fundamental types here
+        >;
 
-    /// Type list of every C++ representation types supported by default, in order matching `data_type` related values.
+    /// Type list of every C++ representation types supported by default, in order matching `data_type`
+    /// related values.
     static constexpr all_base_types_t all_base_types;
 
     /// Matches C++ representation types which are supported by default.
-    template< class T >
+    template <class T>
     concept is_arrow_base_type = mpl::contains<T>(all_base_types);
 
     /// Provides compile-time information about Arrow data types.
@@ -123,68 +128,60 @@ namespace sparrow
     ///
     /// @note: See ./arrow_traits.hpp for implementations for default base types.
     /// @see `is_arrow_traits`, `has_arrow_type_traits`
-    template<class T>
+    template <class T>
     struct arrow_traits;
 
     /// Matches valid and complete `arrow_traits` specializations for type T.
     /// Every type that needs to be compatible with this library's interface must
     /// provide a specialization of `arrow_traits`
     /// @see `arrow_traits`, `has_arrow_type_traits`
-    template<class T>
-    concept is_arrow_traits = mpl::is_type_instance_of_v< T, arrow_traits >
-        and requires
-        {
-            /// Must provide a compile-time value of type `data_type`.
-            /// This is used to identify which arrow data type is represented in `value_type`
-            requires std::same_as< std::remove_cvref_t<decltype(T::type_id)>, ::sparrow::data_type >;
+    template <class T>
+    concept is_arrow_traits = mpl::is_type_instance_of_v<T, arrow_traits> and requires {
+        /// Must provide a compile-time value of type `data_type`.
+        /// This is used to identify which arrow data type is represented in `value_type`
+        requires std::same_as<std::remove_cvref_t<decltype(T::type_id)>, ::sparrow::data_type>;
 
-            /// The C++ representation of the arrow value. For `arrow_traits<X>`, this is usually `X`.
-            typename T::value_type;
+        /// The C++ representation of the arrow value. For `arrow_traits<X>`, this is usually `X`.
+        typename T::value_type;
 
-            /// The arrow (binary) layout to use by default for representing a set of data for that type.
-            typename T::default_layout;
+        /// The arrow (binary) layout to use by default for representing a set of data for that type.
+        typename T::default_layout;
 
-            // TODO: add more interface requirements on the traits here
-            // TODO: add conversion operations between bytes and the value type
-        }
-        ;
+        // TODO: add more interface requirements on the traits here
+        // TODO: add conversion operations between bytes and the value type
+    };
 
 
     /// Matches types providing valid and complete `arrow_traits` specialization.
     /// @see `is_arrow_traits`, `arrow_traits`
-    template< class T >
-    concept has_arrow_type_traits =
-        requires { typename ::sparrow::arrow_traits<T>; }
-        and is_arrow_traits< ::sparrow::arrow_traits<T> >
-        ;
+    template <class T>
+    concept has_arrow_type_traits = requires { typename ::sparrow::arrow_traits<T>; }
+                                    and is_arrow_traits<::sparrow::arrow_traits<T>>;
 
-    /// Matches any type which is one of the base C++ types supported or at least that provides an `arrow_traits` specialization.
-    template< class T >
+    /// Matches any type which is one of the base C++ types supported or at least that provides an
+    /// `arrow_traits` specialization.
+    template <class T>
     concept any_arrow_type = is_arrow_base_type<T> or has_arrow_type_traits<T>;
 
     /// @returns Arrow type id to use for a given C++ representation of that type.
     /// @see `arrow_traits`
-    template< has_arrow_type_traits T >
-    constexpr
-    auto arrow_type_id() -> data_type
+    template <has_arrow_type_traits T>
+    constexpr auto arrow_type_id() -> data_type
     {
         return arrow_traits<T>::type_id;
     }
 
     /// @returns Arrow type id to use for the type of a given object.
     /// @see `arrow_traits`
-    template< has_arrow_type_traits T >
-    constexpr
-    auto arrow_type_id(const T&) -> data_type
+    template <has_arrow_type_traits T>
+    constexpr auto arrow_type_id(const T&) -> data_type
     {
         return arrow_type_id<T>();
     }
 
-
     /// Binary layout type to use by default for the given C++ representation T of an arrow value.
-    template< has_arrow_type_traits T >
+    template <has_arrow_type_traits T>
     using default_layout_t = typename arrow_traits<T>::default_layout;
-
 
     // For now, a tiny wrapper around data_type
     // More data and functions to come
@@ -202,13 +199,15 @@ namespace sparrow
         {
         }
 
-        constexpr data_type id() const { return m_id; }
+        constexpr data_type id() const
+        {
+            return m_id;
+        }
 
     private:
 
         data_type m_id;
     };
-
 
     namespace impl
     {
@@ -226,6 +225,4 @@ namespace sparrow
     concept layout_offset = std::same_as<T, std::int32_t> || std::same_as<T, std::int64_t>;
 
 
-
 }
-

--- a/include/sparrow/details/3rdparty/.clang-format
+++ b/include/sparrow/details/3rdparty/.clang-format
@@ -1,0 +1,3 @@
+{
+    "DisableFormat": true,
+}

--- a/include/sparrow/dictionary_encoded_layout.hpp
+++ b/include/sparrow/dictionary_encoded_layout.hpp
@@ -15,10 +15,9 @@
 #pragma once
 
 #include "sparrow/array_data.hpp"
-#include "sparrow/iterator.hpp"
 #include "sparrow/fixed_size_layout.hpp"
-#include "sparrow/mp_utils.hpp"
 #include "sparrow/iterator.hpp"
+#include "sparrow/mp_utils.hpp"
 
 namespace sparrow
 {
@@ -41,18 +40,14 @@ namespace sparrow
     public:
 
         using self_type = dictionary_value_iterator<IL, SL, is_const>;
-        using base_type = iterator_base<
-            self_type,
-            typename SL::value_type,
-            std::random_access_iterator_tag,
-            typename SL::const_reference>;
+        using base_type = iterator_base<self_type, typename SL::value_type, std::random_access_iterator_tag, typename SL::const_reference>;
         using reference = typename base_type::reference;
         using difference_type = typename base_type::difference_type;
 
         using index_iterator = std::conditional_t<is_const, typename IL::const_value_iterator, typename IL::value_iterator>;
         using sub_layout = mpl::constify_t<SL, is_const>;
         using sub_layout_reference = sub_layout&;
-        
+
         // `dictionary_value_iterator` needs to be default constructible
         // to satisfy `dictionary_encoded_layout::const_value_range`'s
         // constraints.
@@ -60,6 +55,7 @@ namespace sparrow
         dictionary_value_iterator(index_iterator index_it, sub_layout_reference sub_layout_reference);
 
     private:
+
         reference dereference() const;
         void increment();
         void decrement();
@@ -105,6 +101,7 @@ namespace sparrow
     class dictionary_encoded_layout
     {
     public:
+
         using self_type = dictionary_encoded_layout<IT, SL, OT>;
         using index_type = IT;
         using inner_value_type = SL::inner_value_type;
@@ -151,7 +148,7 @@ namespace sparrow
         dictionary_encoded_layout& operator=(const dictionary_encoded_layout&) = delete;
         dictionary_encoded_layout(dictionary_encoded_layout&&) = delete;
         dictionary_encoded_layout& operator=(dictionary_encoded_layout&&) = delete;
-        
+
         size_type size() const;
         const_reference operator[](size_type i) const;
 
@@ -162,6 +159,7 @@ namespace sparrow
         const_value_range values() const;
 
     private:
+
         const indexes_layout& get_const_indexes_layout() const;
 
         const_value_iterator value_cbegin() const;
@@ -176,7 +174,8 @@ namespace sparrow
         std::unique_ptr<indexes_layout> m_indexes_layout;
         std::unique_ptr<sub_layout> m_sub_layout;
 
-        static const const_reference& dummy_const_reference(){
+        static const const_reference& dummy_const_reference()
+        {
             static const typename sub_layout::inner_value_type dummy_inner_value;
             static const typename sub_layout::bitmap_type dummy_bitmap(1, false);
             static const const_reference instance(dummy_inner_value, dummy_bitmap[0]);
@@ -192,7 +191,10 @@ namespace sparrow
      *******************************************/
 
     template <class L, class SL, bool is_const>
-    dictionary_value_iterator<L, SL, is_const>::dictionary_value_iterator(index_iterator index_it, sub_layout_reference sub_layout_reference)
+    dictionary_value_iterator<L, SL, is_const>::dictionary_value_iterator(
+        index_iterator index_it,
+        sub_layout_reference sub_layout_reference
+    )
         : m_index_it(index_it)
         , m_sub_layout_reference(sub_layout_reference)
     {
@@ -264,10 +266,12 @@ namespace sparrow
     {
         assert(i < size());
         const auto index = (*m_indexes_layout)[i];
-        if (index.has_value()) {
+        if (index.has_value())
+        {
             return (*m_sub_layout)[index.value()];
         }
-        else {
+        else
+        {
             return dummy_const_reference();
         }
     }
@@ -279,7 +283,8 @@ namespace sparrow
     }
 
     template <std::integral T, class SL, layout_offset OT>
-    const typename dictionary_encoded_layout<T, SL, OT>::indexes_layout& dictionary_encoded_layout<T, SL, OT>::get_const_indexes_layout() const
+    const typename dictionary_encoded_layout<T, SL, OT>::indexes_layout&
+    dictionary_encoded_layout<T, SL, OT>::get_const_indexes_layout() const
     {
         return *const_cast<const indexes_layout*>(m_indexes_layout.get());
     }

--- a/include/sparrow/dynamic_bitset.hpp
+++ b/include/sparrow/dynamic_bitset.hpp
@@ -221,7 +221,7 @@ namespace sparrow
         void assign(bool) noexcept;
         void set() noexcept;
         void reset() noexcept;
-        
+
         bitset_type& m_bitset;
         block_type& m_block;
         block_type m_mask;
@@ -248,24 +248,20 @@ namespace sparrow
      * a const iterator.
      */
     template <class B, bool is_const>
-    class bitset_iterator : public iterator_base
-    <
-        bitset_iterator<B, is_const>,
-        mpl::constify_t<typename B::value_type, is_const>,
-        std::random_access_iterator_tag,
-        std::conditional_t<is_const, bool, bitset_reference<B>>
-    >
+    class bitset_iterator : public iterator_base<
+                                bitset_iterator<B, is_const>,
+                                mpl::constify_t<typename B::value_type, is_const>,
+                                std::random_access_iterator_tag,
+                                std::conditional_t<is_const, bool, bitset_reference<B>>>
     {
     public:
-        
+
         using self_type = bitset_iterator<B, is_const>;
-        using base_type = iterator_base
-        <
+        using base_type = iterator_base<
             self_type,
             mpl::constify_t<typename B::value_type, is_const>,
             std::contiguous_iterator_tag,
-            std::conditional_t<is_const, bool, bitset_reference<B>>
-        >;        
+            std::conditional_t<is_const, bool, bitset_reference<B>>>;
         using reference = typename base_type::reference;
         using difference_type = typename base_type::difference_type;
 
@@ -297,7 +293,7 @@ namespace sparrow
 
         friend class iterator_access;
     };
-        
+
     /**************************************
      * dynamic_bitset_base implementation *
      **************************************/
@@ -439,8 +435,7 @@ namespace sparrow
     template <random_access_range B>
     auto dynamic_bitset_base<B>::compute_block_count(size_type bits_count) const noexcept -> size_type
     {
-        return bits_count / s_bits_per_block
-            + static_cast<size_type>(bits_count % s_bits_per_block != 0);
+        return bits_count / s_bits_per_block + static_cast<size_type>(bits_count % s_bits_per_block != 0);
     }
 
     template <random_access_range B>
@@ -465,12 +460,13 @@ namespace sparrow
     auto dynamic_bitset_base<B>::count_non_null() const noexcept -> size_type
     {
         if (m_buffer.empty())
+        {
             return 0u;
+        }
 
         // Number of bits set to 1 in i for i from 0 to 255.
         // This can be seen as a mapping "uint8_t -> number of non null bits"
-        static constexpr unsigned char table[] =
-        {
+        static constexpr unsigned char table[] = {
             0, 1, 1, 2, 1, 2, 2, 3, 1, 2, 2, 3, 2, 3, 3, 4, 1, 2, 2, 3, 2, 3, 3, 4, 2, 3, 3, 4, 3, 4, 4, 5,
             1, 2, 2, 3, 2, 3, 3, 4, 2, 3, 3, 4, 3, 4, 4, 5, 2, 3, 3, 4, 3, 4, 4, 5, 3, 4, 4, 5, 4, 5, 5, 6,
             1, 2, 2, 3, 2, 3, 3, 4, 2, 3, 3, 4, 3, 4, 4, 5, 2, 3, 3, 4, 3, 4, 4, 5, 3, 4, 4, 5, 4, 5, 5, 6,
@@ -490,8 +486,6 @@ namespace sparrow
         }
         return res;
     }
-
-
 
     template <random_access_range B>
     auto dynamic_bitset_base<B>::count_extra_bits() const noexcept -> size_type
@@ -516,7 +510,7 @@ namespace sparrow
         {
             --m_null_count;
         }
-        else if(!new_value && old_value)
+        else if (!new_value && old_value)
         {
             ++m_null_count;
         }
@@ -566,10 +560,7 @@ namespace sparrow
 
     template <std::integral T>
     dynamic_bitset<T>::dynamic_bitset(size_type n, value_type value)
-        : base_type(
-            storage_type(this->compute_block_count(n), value ? ~block_type(0) : 0),
-            n,
-            value ? 0u : n)
+        : base_type(storage_type(this->compute_block_count(n), value ? ~block_type(0) : 0), n, value ? 0u : n)
     {
     }
 
@@ -631,7 +622,7 @@ namespace sparrow
         }
         return *this;
     }
-    
+
     template <class B>
     auto bitset_reference<B>::operator|=(bool rhs) noexcept -> self_type&
     {
@@ -641,7 +632,7 @@ namespace sparrow
         }
         return *this;
     }
-    
+
     template <class B>
     auto bitset_reference<B>::operator^=(bool rhs) noexcept -> self_type&
     {
@@ -708,7 +699,7 @@ namespace sparrow
     {
         assert(m_index < bitset_type::s_bits_per_block);
     }
-    
+
     template <class B, bool is_const>
     auto bitset_iterator<B, is_const>::dereference() const -> reference
     {
@@ -763,7 +754,7 @@ namespace sparrow
             else
             {
                 size_type to_next_block = bitset_type::s_bits_per_block - m_index;
-                n -=  to_next_block;
+                n -= to_next_block;
                 size_type block_n = n / bitset_type::s_bits_per_block;
                 p_block += block_n + 1;
                 n -= block_n * bitset_type::s_bits_per_block;

--- a/include/sparrow/fixed_size_layout.hpp
+++ b/include/sparrow/fixed_size_layout.hpp
@@ -15,14 +15,14 @@
 #pragma once
 
 #include <algorithm>
+#include <cassert>
 #include <concepts>
 #include <cstdint>
-#include <cassert>
 
 #include "sparrow/array_data.hpp"
-#include "sparrow/iterator.hpp"
 #include "sparrow/buffer.hpp"
 #include "sparrow/dynamic_bitset.hpp"
+#include "sparrow/iterator.hpp"
 
 namespace sparrow
 {
@@ -71,7 +71,7 @@ namespace sparrow
         using const_iterator = layout_iterator<self_type, true>;
 
         explicit fixed_size_layout(array_data& data);
-        
+
         fixed_size_layout(const self_type&) = delete;
         self_type& operator=(const self_type&) = delete;
         fixed_size_layout(self_type&&) = delete;
@@ -117,7 +117,7 @@ namespace sparrow
         const array_data& data_ref() const;
 
         std::reference_wrapper<array_data> m_data;
-        
+
         friend class reference_proxy<fixed_size_layout>;
         friend class const_reference_proxy<fixed_size_layout>;
     };
@@ -294,6 +294,4 @@ namespace sparrow
         return m_data.get();
     }
 
-} // namespace sparrow
-
-
+}  // namespace sparrow

--- a/include/sparrow/iterator.hpp
+++ b/include/sparrow/iterator.hpp
@@ -90,14 +90,7 @@ namespace sparrow
     // output_iterator_tag and input_iterator_tag are not supported.
     // This allows a lot of simplifications regarding the definitions of
     // postfix increment operators and related methods.
-    template
-    <
-        class Derived,
-        class IteratorConcept,
-        class Element,
-        class Reference,
-        class Difference
-    >
+    template <class Derived, class IteratorConcept, class Element, class Reference, class Difference>
     class iterator_root_base;
 
     // Utility class for accessing private methods
@@ -128,12 +121,13 @@ namespace sparrow
             it.advance(n);
         }
 
-#if _WIN32 // Workaround for access issue with msvc, when friend is involved
+#if _WIN32  // Workaround for access issue with msvc, when friend is involved
+
     public:
+
 #endif
         template <class It>
-        static typename It::difference_type
-        distance_to(const It& lhs, const It& rhs)
+        static typename It::difference_type distance_to(const It& lhs, const It& rhs)
         {
             return lhs.distance_to(rhs);
         }
@@ -149,8 +143,10 @@ namespace sparrow
         {
             return lhs.less_than(rhs);
         }
-#if _WIN32 // Workaround for access issue with msvc, when friend is involved
+#if _WIN32  // Workaround for access issue with msvc, when friend is involved
+
     private:
+
 #endif
         template <class Derived, class E, class T, class R, class D>
         friend class iterator_root_base;
@@ -166,13 +162,7 @@ namespace sparrow
     };
 
     // Specialization of iterator_root_base for forward iterator.
-    template
-    <
-        class Derived,
-        class Element,
-        class Reference,
-        class Difference
-    >
+    template <class Derived, class Element, class Reference, class Difference>
     class iterator_root_base<Derived, Element, std::forward_iterator_tag, Reference, Difference>
     {
     private:
@@ -231,13 +221,7 @@ namespace sparrow
     };
 
     // Specialization of iterator_root_base for bidirectional iterator.
-    template
-    <
-        class Derived,
-        class Element,
-        class Reference,
-        class Difference
-    >
+    template <class Derived, class Element, class Reference, class Difference>
     class iterator_root_base<Derived, Element, std::bidirectional_iterator_tag, Reference, Difference>
         : public iterator_root_base<Derived, Element, std::forward_iterator_tag, Reference, Difference>
     {
@@ -263,13 +247,7 @@ namespace sparrow
     };
 
     // Specialization of iterator_root_base for random access iterator.
-    template
-    <
-        class Derived,
-        class Element,
-        class Reference,
-        class Difference
-    >
+    template <class Derived, class Element, class Reference, class Difference>
     class iterator_root_base<Derived, Element, std::random_access_iterator_tag, Reference, Difference>
         : public iterator_root_base<Derived, Element, std::bidirectional_iterator_tag, Reference, Difference>
     {
@@ -324,20 +302,23 @@ namespace sparrow
 
         friend inline std::strong_ordering operator<=>(const derived_type& lhs, const derived_type& rhs)
         {
-            if (iterator_access::less_than(lhs, rhs)) { return std::strong_ordering::less; }
-            else if (iterator_access::equal(lhs, rhs)) { return std::strong_ordering::equal; }
-            else { return std::strong_ordering::greater; }
+            if (iterator_access::less_than(lhs, rhs))
+            {
+                return std::strong_ordering::less;
+            }
+            else if (iterator_access::equal(lhs, rhs))
+            {
+                return std::strong_ordering::equal;
+            }
+            else
+            {
+                return std::strong_ordering::greater;
+            }
         }
     };
 
     // Specialization of iterator_root_base for contiguous iterator.
-    template
-    <
-        class Derived,
-        class Element,
-        class Reference,
-        class Difference
-    >
+    template <class Derived, class Element, class Reference, class Difference>
     class iterator_root_base<Derived, Element, std::contiguous_iterator_tag, Reference, Difference>
         : public iterator_root_base<Derived, Element, std::random_access_iterator_tag, Reference, Difference>
     {
@@ -350,7 +331,6 @@ namespace sparrow
 #endif
         using iterator_concept = std::contiguous_iterator_tag;
     };
-
 
     /*
      * @class iterator_base
@@ -389,16 +369,8 @@ namespace sparrow
      * (except for contiguous_iterator, where it is `random_access_iterator_tag`). This can be overloaded
      * in the inheriting iterator class.
      */
-    template
-    <
-        class Derived,
-        class Element,
-        class IteratorConcept,
-        class Reference = Element&,
-        class Difference = std::ptrdiff_t
-    >
-    class iterator_base
-        : public iterator_root_base<Derived, Element, IteratorConcept, Reference, Difference>
+    template <class Derived, class Element, class IteratorConcept, class Reference = Element&, class Difference = std::ptrdiff_t>
+    class iterator_base : public iterator_root_base<Derived, Element, IteratorConcept, Reference, Difference>
     {
     };
 
@@ -411,17 +383,14 @@ namespace sparrow
      * inherit from this class and redefine the private methods
      * they need only.
      */
-    template
-    <
+    template <
         class Derived,
         class Iter,
         class Element,
         class IteratorConcept = typename std::iterator_traits<Iter>::iterator_category,
         class Reference = std::iter_reference_t<Iter>,
-        class Difference = std::iter_difference_t<Iter>
-    >
-    class iterator_adaptor
-        : public iterator_base<Derived, Element, IteratorConcept, Reference, Difference>
+        class Difference = std::iter_difference_t<Iter>>
+    class iterator_adaptor : public iterator_base<Derived, Element, IteratorConcept, Reference, Difference>
     {
     public:
 
@@ -432,6 +401,7 @@ namespace sparrow
         using iterator_type = Iter;
 
         iterator_adaptor() = default;
+
         explicit iterator_adaptor(const iterator_type& iter)
             : p_iter(iter)
         {
@@ -478,7 +448,7 @@ namespace sparrow
         {
             return p_iter < rhs.p_iter;
         }
-        
+
         iterator_type p_iter = {};
 
         friend class iterator_access;
@@ -499,19 +469,20 @@ namespace sparrow
         : public iterator_adaptor<pointer_iterator<T*>, T*, T, std::contiguous_iterator_tag>
     {
     public:
-        
+
         using self_type = pointer_iterator<T*>;
         using base_type = iterator_adaptor<self_type, T*, T, std::contiguous_iterator_tag>;
         using iterator_type = typename base_type::iterator_type;
-        
+
         pointer_iterator() = default;
+
         explicit pointer_iterator(iterator_type p)
             : base_type(p)
         {
         }
 
         template <class U>
-        requires std::convertible_to<U*, iterator_type>
+            requires std::convertible_to<U*, iterator_type>
         explicit pointer_iterator(U* u)
             : base_type(iterator_type(u))
         {

--- a/include/sparrow/mp_utils.hpp
+++ b/include/sparrow/mp_utils.hpp
@@ -14,41 +14,49 @@
 
 #pragma once
 
-#include <type_traits>
 #include <iterator>
+#include <type_traits>
 
 namespace sparrow::mpl
 {
     /// A sequence of types, used for meta-programming operations.
-    template< class... T >
-    struct typelist {};
+    template <class... T>
+    struct typelist
+    {
+    };
 
     /// @returns The count of types contained in a given `typelist`.
-    template< class... T >
-    constexpr std::size_t size(typelist<T...> = {}) { return sizeof...(T); }
+    template <class... T>
+    constexpr std::size_t size(typelist<T...> = {})
+    {
+        return sizeof...(T);
+    }
 
-    template< class L, template<class...> class U >
-    struct is_type_instance_of : std::false_type {};
+    template <class L, template <class...> class U>
+    struct is_type_instance_of : std::false_type
+    {
+    };
 
-    template< template<class...> class L, template<class...> class U, class... T>
-        requires std::is_same_v< L<T...>, U<T...> >
-    struct is_type_instance_of< L<T...>, U > : std::true_type {};
+    template <template <class...> class L, template <class...> class U, class... T>
+        requires std::is_same_v<L<T...>, U<T...>>
+    struct is_type_instance_of<L<T...>, U> : std::true_type
+    {
+    };
 
     /// `true` if `T` is a concrete type template instanciation of `U` which is a type template.
     /// Example: is_type_instance_of_v< std::vector<int>, std::vector > == true
-    template< class T, template< class... > class U >
+    template <class T, template <class...> class U>
     constexpr bool is_type_instance_of_v = is_type_instance_of<T, U>::value;
 
     /// Matches any type which is an instance of `typelist`.
     /// Examples:
     ///     static_assert(any_typelist< typelist<int, float, std::vector<int> > > == true);
     ///     static_assert(any_typelist< std::vector<int> > == false);
-    template< typename TList >
+    template <typename TList>
     concept any_typelist = is_type_instance_of_v<TList, typelist>;
 
     template <class T, bool is_const>
-    struct constify
-        : std::conditional<is_const, const T, T>
+    struct constify : std::conditional<is_const, const T, T>
     {
     };
 
@@ -61,16 +69,13 @@ namespace sparrow::mpl
     //// Type-predicates /////////////////////////////
 
     /// Matches template types which can be used as type-wrappers for evaluation in type-predicates.
-    template< template< class... > class W, class T >
-    concept type_wrapper = std::same_as<W<T>, typelist<T>>
-                        or std::same_as<W<T>, std::type_identity_t<T>>
-                        ;
+    template <template <class...> class W, class T>
+    concept type_wrapper = std::same_as<W<T>, typelist<T>> or std::same_as<W<T>, std::type_identity_t<T>>;
 
     /// Matches template types that can be evaluated at compile-time similarly to `std::true/false_type`
     /// This makes possible to use predicates provided by the standard.
-    template< template<class> class P, class T >
-    concept ct_type_predicate = requires
-    {
+    template <template <class> class P, class T>
+    concept ct_type_predicate = requires {
         { P<T>::value } -> std::convertible_to<bool>;
     };
 
@@ -93,23 +98,23 @@ namespace sparrow::mpl
             )
         ;
 
-
-
-    /// Evaluates the provided compile-time template class predicate P given a type T, if P is of a similar shape to `std::true/false_type`.
-    template<class T, template<class> class P>
-        requires ct_type_predicate<P,T>
-    consteval
-    bool evaluate(P<T>)
+    /// Evaluates the provided compile-time template class predicate P given a type T, if P is of a similar
+    /// shape to `std::true/false_type`.
+    template <class T, template <class> class P>
+        requires ct_type_predicate<P, T>
+    consteval bool evaluate(P<T>)
     {
         return P<T>::value;
     }
 
-    /// Evaluates the provided compile-time template class predicate P given a type T, if P's instance is callable given a value type wrapper of T.
-    template<class T, callable_type_predicate<T> P>
-    consteval
-    bool evaluate(P predicate)
+    /// Evaluates the provided compile-time template class predicate P given a type T, if P's instance is
+    /// callable given a value type wrapper of T.
+    template <class T, callable_type_predicate<T> P>
+    consteval bool evaluate(P predicate)
     {
-        if constexpr (requires (std::decay_t<P> p){ { p(typelist<T>{}) } -> std::same_as<bool>; })
+        if constexpr (requires(std::decay_t<P> p) {
+                          { p(typelist<T>{}) } -> std::same_as<bool>;
+                      })
         {
             return predicate(typelist<T>{});
         }
@@ -128,39 +133,36 @@ namespace sparrow::mpl
         ///     static constexpr auto same_as_int = same_as<int>{};
         ///     static_assert( any_of(some_types, same_as_int) == true);
         ///     static_assert( all_of(some_types, same_as_int) == false);
-        template<class T>
+        template <class T>
         struct same_as
         {
-            template<template<class...> class W, class X>
+            template <template <class...> class W, class X>
                 requires type_wrapper<W, X>
             consteval bool operator()(W<X>) const
             {
-                return std::same_as< T, X >;
+                return std::same_as<T, X>;
             }
-
         };
     }
 
-    template< template<class> class P >
+    template <template <class> class P>
     struct ct_type_predicate_to_callable
     {
-        template<template<class...> class W, class T>
-            requires ct_type_predicate<P, T> and type_wrapper<W,T>
+        template <template <class...> class W, class T>
+            requires ct_type_predicate<P, T> and type_wrapper<W, T>
         consteval bool operator()(W<T>) const
         {
             return P<T>::value;
         }
     };
 
-    /// @returns A callable type-predicate object which will return `P<T>::value` when called with `T` in a type-wrapper.
-    template< template<class> class P >
-    consteval
-    auto as_predicate()
+    /// @returns A callable type-predicate object which will return `P<T>::value` when called with `T` in a
+    /// type-wrapper.
+    template <template <class> class P>
+    consteval auto as_predicate()
     {
         return ct_type_predicate_to_callable<P>{};
     };
-
-
 
     //////////////////////////////////////////////////
     //// Algorithms //////////////////////////////////
@@ -168,10 +170,9 @@ namespace sparrow::mpl
     /// Checks that at least one type in the provided list of is making the provide predicate return `true`.
     /// @returns 'true' if for at least one type T in the type list L,, `Predicate{}(typelist<T>) == true`.
     ///          `false` otherwise or if the list is empty.
-    template< class Predicate, template<class...> class L, class... T>
+    template <class Predicate, template <class...> class L, class... T>
         requires any_typelist<L<T...>> and (callable_type_predicate<Predicate, T> && ...)
-    consteval
-    bool any_of(L<T...> list, Predicate predicate = {})
+    consteval bool any_of(L<T...> list, Predicate predicate = {})
     {
         return (evaluate<T>(predicate) || ... || false);
     }
@@ -179,10 +180,9 @@ namespace sparrow::mpl
     /// Checks that at least one type in the provided list of is making the provide predicate return `true`.
     /// @returns 'true' if for at least one type T in the type list L, `Predicate<T>::value == true`.
     ///          `false` otherwise or if the list is empty.
-    template< template<class> class Predicate, template<class...> class L, class... T>
+    template <template <class> class Predicate, template <class...> class L, class... T>
         requires any_typelist<L<T...>> and (ct_type_predicate<Predicate, T> && ...)
-    consteval
-    bool any_of(L<T...> list)
+    consteval bool any_of(L<T...> list)
     {
         return any_of(list, as_predicate<Predicate>());
     }
@@ -190,10 +190,9 @@ namespace sparrow::mpl
     /// Checks that every type in the provided list of is making the provide predicate return `true`.
     /// @returns `true` if for every type T in the type list L, `Predicate{}(typelist<T>) == true`
     ///          or if the list is empty; `false` otherwise.
-    template< class Predicate, template<class...> class L, class... T>
+    template <class Predicate, template <class...> class L, class... T>
         requires any_typelist<L<T...>> and (callable_type_predicate<Predicate, T> && ...)
-    consteval
-    bool all_of(L<T...> list, Predicate predicate)
+    consteval bool all_of(L<T...> list, Predicate predicate)
     {
         return (evaluate<T>(predicate) && ... && true);
     }
@@ -201,33 +200,30 @@ namespace sparrow::mpl
     /// Checks that every type in the provided list of is making the provide predicate return `true`.
     /// @returns `true` if for every type T in the type list L, `Predicate<T>::value == true`
     ///          or if the list is empty; `false` otherwise.
-    template< template<class> class Predicate, template<class...> class L, class... T>
+    template <template <class> class Predicate, template <class...> class L, class... T>
         requires any_typelist<L<T...>> and (ct_type_predicate<Predicate, T> && ...)
-    consteval
-        bool all_of(L<T...> list)
+    consteval bool all_of(L<T...> list)
     {
         return all_of(list, as_predicate<Predicate>());
     }
 
-
     /// @returns `true` if the provided type list contains `V`
-    template< class V, any_typelist L>
-    consteval
-    bool contains(L list)
+    template <class V, any_typelist L>
+    consteval bool contains(L list)
     {
         return any_of(list, predicate::same_as<V>{});
     }
 
-
-    /// @returns The index position in the first type in the provided type list `L` that matches the provided predicate,
+    /// @returns The index position in the first type in the provided type list `L` that matches the provided
+    /// predicate,
     ///          or the size of the list if the matching type was not found.
-    template< class Predicate, template<class...> class L, class... T>
+    template <class Predicate, template <class...> class L, class... T>
         requires any_typelist<L<T...>> and (callable_type_predicate<Predicate, T> && ...)
-    consteval
-    std::size_t find_if(L<T...> list, Predicate predicate)
+    consteval std::size_t find_if(L<T...> list, Predicate predicate)
     {
         std::size_t idx = 0;
-        auto check = [&](bool match_success){
+        auto check = [&](bool match_success)
+        {
             if (match_success)
             {
                 return true;
@@ -244,27 +240,23 @@ namespace sparrow::mpl
         return idx;
     }
 
-
-    /// @returns The index position in the first type in the provided type list `L` that matches the provided predicate,
+    /// @returns The index position in the first type in the provided type list `L` that matches the provided
+    /// predicate,
     ///          or the size of the list if the matching type was not found.
-    template< template<class> class Predicate, template<class...> class L, class... T>
+    template <template <class> class Predicate, template <class...> class L, class... T>
         requires any_typelist<L<T...>> and (ct_type_predicate<Predicate, T> && ...)
-    consteval
-        std::size_t find_if(L<T...> list)
+    consteval std::size_t find_if(L<T...> list)
     {
         return find_if(list, as_predicate<Predicate>());
     }
 
-
     /// @returns The index position in the type `TypeToFind` in the provided type list `L`,
     ///          or the size of the list if the matching type was not found.
-    template< class TypeToFind, any_typelist L>
-    consteval
-    std::size_t find(L list)
+    template <class TypeToFind, any_typelist L>
+    consteval std::size_t find(L list)
     {
         return find_if(list, predicate::same_as<TypeToFind>{});
     }
-
 
 
 }

--- a/include/sparrow/sparrow_version.hpp
+++ b/include/sparrow/sparrow_version.hpp
@@ -20,4 +20,3 @@ namespace sparrow
     constexpr int SPARROW_VERSION_MINOR = 0;
     constexpr int SPARROW_VERSION_PATCH = 1;
 }
-

--- a/include/sparrow/variable_size_binary_layout.hpp
+++ b/include/sparrow/variable_size_binary_layout.hpp
@@ -17,9 +17,9 @@
 #include <functional>
 #include <ranges>
 
-#include "sparrow/mp_utils.hpp"
 #include "sparrow/array_data.hpp"
 #include "sparrow/iterator.hpp"
+#include "sparrow/mp_utils.hpp"
 
 namespace sparrow
 {
@@ -33,39 +33,28 @@ namespace sparrow
      * @tparam is_const a boolean flag specifying whether this iterator is const.
      */
     template <class L, bool is_const>
-    class vs_binary_value_iterator : public iterator_base
-    <
-        vs_binary_value_iterator<L, is_const>,
-        mpl::constify_t<typename L::inner_value_type, is_const>,
-        std::contiguous_iterator_tag,
-        impl::get_inner_reference_t<L, is_const>
-    >
+    class vs_binary_value_iterator : public iterator_base<
+                                         vs_binary_value_iterator<L, is_const>,
+                                         mpl::constify_t<typename L::inner_value_type, is_const>,
+                                         std::contiguous_iterator_tag,
+                                         impl::get_inner_reference_t<L, is_const>>
     {
     public:
 
         using self_type = vs_binary_value_iterator<L, is_const>;
-        using base_type = iterator_base
-        <
+        using base_type = iterator_base<
             self_type,
             mpl::constify_t<typename L::inner_value_type, is_const>,
             std::contiguous_iterator_tag,
-            impl::get_inner_reference_t<L, is_const>
-        >;
+            impl::get_inner_reference_t<L, is_const>>;
         using reference = typename base_type::reference;
         using difference_type = typename base_type::difference_type;
 
-        using offset_iterator = std::conditional_t<
-            is_const, typename L::const_offset_iterator, typename L::offset_iterator
-        >;
-        using data_iterator = std::conditional_t<
-            is_const, typename L::const_data_iterator, typename L::data_iterator
-        >;
+        using offset_iterator = std::conditional_t<is_const, typename L::const_offset_iterator, typename L::offset_iterator>;
+        using data_iterator = std::conditional_t<is_const, typename L::const_data_iterator, typename L::data_iterator>;
 
         vs_binary_value_iterator() noexcept = default;
-        vs_binary_value_iterator(
-            offset_iterator offset_it,
-            data_iterator data_begin
-        );
+        vs_binary_value_iterator(offset_iterator offset_it, data_iterator data_begin);
 
     private:
 
@@ -99,13 +88,14 @@ namespace sparrow
      * Let's consider the array of string ['please', 'allow', 'me', 'to', 'introduce', 'myself'].
      * The internal buffers will be:
      * - offset: [0, 6, 11, 13, 15, 24, 30]
-     * - data: ['p','l','e','a','s','e','a','l','l','o','w','m','e','t','o','i','n','t','r','o','d','u','c','e','m','y','s','e','l','f']
+     * - data:
+     * ['p','l','e','a','s','e','a','l','l','o','w','m','e','t','o','i','n','t','r','o','d','u','c','e','m','y','s','e','l','f']
      *
      * @tparam T the type of the data stored in the data buffer, not its byte representation.
      * @tparam R the reference type to the data. This type is different from the reference type of the layout,
      * which behaves like std::optional<R>.
-     * @tparam CR the const reference type to the data. This type is different from the const reference of the layout,
-     * which behaves like std::optional<CR>.
+     * @tparam CR the const reference type to the data. This type is different from the const reference of the
+     * layout, which behaves like std::optional<CR>.
      * @tparam OT type of the offset values. Must be std::int64_t or std::int32_t.
      */
     template <class T, class R, class CR, layout_offset OT = std::int64_t>
@@ -147,7 +137,7 @@ namespace sparrow
         // TODO: uncomment the following line and implement the non const overloads
         // of `begin` and `end`
         // using iterator = layout_iterator<self_type, false>;
-        
+
         using const_value_range = std::ranges::subrange<const_value_iterator>;
         using const_bitmap_range = std::ranges::subrange<const_bitmap_iterator>;
 
@@ -157,7 +147,7 @@ namespace sparrow
         self_type& operator=(const self_type&) = delete;
         variable_size_binary_layout(self_type&&) = delete;
         self_type& operator=(self_type&&) = delete;
-        
+
         size_type size() const;
         const_reference operator[](size_type i) const;
 
@@ -196,10 +186,7 @@ namespace sparrow
      *******************************************/
 
     template <class L, bool is_const>
-    vs_binary_value_iterator<L, is_const>::vs_binary_value_iterator(
-        offset_iterator offset_it,
-        data_iterator data_begin
-    )
+    vs_binary_value_iterator<L, is_const>::vs_binary_value_iterator(offset_iterator offset_it, data_iterator data_begin)
         : m_offset_it(offset_it)
         , m_data_begin(data_begin)
     {
@@ -256,8 +243,9 @@ namespace sparrow
         : m_data(data)
     {
         assert(data_ref().buffers.size() == 2u);
-        //TODO: templatize back and front in buffer and uncomment the following line
-        //assert(data_ref().buffers[0].size() == 0u || data_ref().buffers[0].back() == data_ref().buffers[1].size());
+        // TODO: templatize back and front in buffer and uncomment the following line
+        // assert(data_ref().buffers[0].size() == 0u || data_ref().buffers[0].back() ==
+        // data_ref().buffers[1].size());
     }
 
     template <class T, class R, class CR, layout_offset OT>
@@ -331,7 +319,7 @@ namespace sparrow
     template <class T, class R, class CR, layout_offset OT>
     auto variable_size_binary_layout<T, R, CR, OT>::value(size_type i) const -> inner_const_reference
     {
-        return inner_const_reference(data(*offset(i)), data(*offset(i+1)));
+        return inner_const_reference(data(*offset(i)), data(*offset(i + 1)));
     }
 
     template <class T, class R, class CR, layout_offset OT>
@@ -367,4 +355,3 @@ namespace sparrow
         return m_data.get();
     }
 }
-

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -18,8 +18,7 @@ enable_testing()
 
 if (CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
     project(sparrow-test CXX)
-
-    find_package(sparrowREQUIRED CONFIG)
+    find_package(sparrow REQUIRED CONFIG)
     set(SPARROW_INCLUDE_DIR ${sparrow_INCLUDE_DIRS})
 endif ()
 

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -13,11 +13,11 @@
 // limitations under the License.
 
 #define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
-#include "doctest/doctest.h"
-
 #include <string>
 
 #include <sparrow/sparrow_version.hpp>
+
+#include "doctest/doctest.h"
 
 TEST_CASE("version is readable")
 {
@@ -25,5 +25,8 @@ TEST_CASE("version is readable")
     // We only try to make sure the version valeus are printable, whatever their type.
     // AKA this is not written to be fancy but to force conversion to string.
     using namespace sparrow;
-    [[maybe_unused]] const std::string printable_version = std::string("sparrow version : ") + std::to_string(SPARROW_VERSION_MAJOR) + "." + std::to_string(SPARROW_VERSION_MINOR) + "." + std::to_string(SPARROW_VERSION_PATCH);
+    [[maybe_unused]] const std::string printable_version = std::string("sparrow version : ")
+                                                           + std::to_string(SPARROW_VERSION_MAJOR) + "."
+                                                           + std::to_string(SPARROW_VERSION_MINOR) + "."
+                                                           + std::to_string(SPARROW_VERSION_PATCH);
 }

--- a/test/test_array_data.cpp
+++ b/test/test_array_data.cpp
@@ -12,10 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "doctest/doctest.h"
-
 #include <initializer_list>
+
 #include "sparrow/array_data.hpp"
+
+#include "doctest/doctest.h"
 
 namespace sparrow
 {
@@ -35,13 +36,14 @@ namespace sparrow
         using size_type = std::size_t;
 
         mock_layout() = default;
+
         mock_layout(std::initializer_list<value_type> l)
             : m_bitmap(l.size())
             , m_data(l.size())
         {
             auto bit_iter = m_bitmap.begin();
             auto value_iter = m_data.begin();
-            for (const auto& v: l)
+            for (const auto& v : l)
             {
                 *bit_iter++ = v.has_value();
                 if (v.has_value())
@@ -91,12 +93,7 @@ namespace sparrow
     {
         ref_proxy_fixture()
         {
-            m_layout = {
-                std::make_optional(2),
-                std::make_optional(5),
-                std::nullopt,
-                std::make_optional(7)
-            };
+            m_layout = {std::make_optional(2), std::make_optional(5), std::nullopt, std::make_optional(7)};
         }
 
         const mock_layout& layout() const
@@ -249,4 +246,3 @@ namespace sparrow
         }
     }
 }
-

--- a/test/test_buffer.cpp
+++ b/test/test_buffer.cpp
@@ -12,11 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "doctest/doctest.h"
-
 #include <numeric>
 
 #include "sparrow/buffer.hpp"
+
+#include "doctest/doctest.h"
 
 namespace sparrow
 {
@@ -106,12 +106,12 @@ namespace sparrow
 
         TEST_CASE("empty")
         {
-           buffer_test_type b1;
-           CHECK(b1.empty());
+            buffer_test_type b1;
+            CHECK(b1.empty());
 
-           const std::size_t size = 4u;
-           buffer_test_type b2(make_test_buffer(size), size);
-           CHECK(!b2.empty());
+            const std::size_t size = 4u;
+            buffer_test_type b2(make_test_buffer(size), size);
+            CHECK(!b2.empty());
         }
 
         TEST_CASE("operator[]")
@@ -119,7 +119,7 @@ namespace sparrow
             const std::size_t size = 4u;
             buffer_test_type b1(make_test_buffer(size), size);
             const buffer_test_type b2(b1);
-            for(std::size_t i = 0; i < size; ++i)
+            for (std::size_t i = 0; i < size; ++i)
             {
                 CHECK_EQ(b1[i], i);
                 CHECK_EQ(b2[i], i);
@@ -150,7 +150,7 @@ namespace sparrow
         {
             const std::size_t size = 4u;
             buffer_test_type b1(make_test_buffer(size), size);
-            
+
             const uint8_t expected_value = 101;
             const std::size_t idx = 3u;
             b1.data()[idx] = expected_value;
@@ -193,7 +193,7 @@ namespace sparrow
         {
             const std::size_t size1 = 4u;
             const std::size_t size2 = 8u;
-            buffer_test_type b(make_test_buffer(size1), size1); 
+            buffer_test_type b(make_test_buffer(size1), size1);
             b.resize(size2);
             CHECK_EQ(b.size(), size2);
             CHECK_EQ(b.data()[2], 2);
@@ -211,7 +211,7 @@ namespace sparrow
         TEST_CASE("clear")
         {
             const std::size_t size1 = 4u;
-            buffer_test_type b(make_test_buffer(size1), size1); 
+            buffer_test_type b(make_test_buffer(size1), size1);
             b.clear();
             CHECK_EQ(b.size(), 0u);
         }
@@ -239,8 +239,8 @@ namespace sparrow
             auto citer = b.crbegin();
             for (std::size_t i = b.size(); i != 0u; --i)
             {
-                CHECK_EQ(*iter++, b[i-1]);
-                CHECK_EQ(*citer++, b[i-1]);
+                CHECK_EQ(*iter++, b[i - 1]);
+                CHECK_EQ(*citer++, b[i - 1]);
             }
             CHECK_EQ(iter, b.rend());
             CHECK_EQ(citer, b.crend());
@@ -256,9 +256,8 @@ namespace sparrow
                 uint8_t* mem = make_test_buffer(size);
                 [[maybe_unused]] view_test_type v(mem, size);
             }
-            
+
             {
-                
                 const std::size_t size = 8u;
                 buffer_test_type b(make_test_buffer(size), size);
                 [[maybe_unused]] view_test_type v(b);

--- a/test/test_dictionary_encoded_layout.cpp
+++ b/test/test_dictionary_encoded_layout.cpp
@@ -12,21 +12,21 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "doctest/doctest.h"
-
 #include <algorithm>
+#include <array>
 #include <cstdint>
+#include <iostream>  // For doctest
 #include <numeric>
 #include <string_view>
-#include <array>
-#include <iostream> // For doctest
 
-#include "sparrow/variable_size_binary_layout.hpp"
 #include "sparrow/dictionary_encoded_layout.hpp"
+#include "sparrow/variable_size_binary_layout.hpp"
+
+#include "doctest/doctest.h"
 
 using data_type_t = uint8_t;
 constexpr size_t element_count = 10;
-static const std::array<data_type_t, element_count> indexes {1, 0,3, 0, 1, 2, 3, 2, 4, 2};
+static const std::array<data_type_t, element_count> indexes{1, 0, 3, 0, 1, 2, 3, 2, 4, 2};
 
 namespace sparrow
 {
@@ -39,7 +39,7 @@ namespace sparrow
             m_data.bitmap.set(9, false);
             constexpr size_t buffer_size = (element_count * sizeof(data_type_t)) / sizeof(uint8_t);
             buffer<uint8_t> b(buffer_size);
-            std::ranges::copy(indexes,b.data<data_type_t>());
+            std::ranges::copy(indexes, b.data<data_type_t>());
             m_data.buffers.push_back(b);
             m_data.length = element_count;
             auto dictionary = make_dictionary();
@@ -53,15 +53,24 @@ namespace sparrow
             dictionary.buffers.resize(2);
             dictionary.buffers[0].resize(sizeof(std::int64_t) * (words.size() + 1));
             dictionary.buffers[1].resize(std::accumulate(
-                words.cbegin(), words.cend(), size_t(0), [](std::size_t res, const auto& s) { return res + s.size(); }
+                words.cbegin(),
+                words.cend(),
+                size_t(0),
+                [](std::size_t res, const auto& s)
+                {
+                    return res + s.size();
+                }
             ));
             dictionary.buffers[0].data<std::int64_t>()[0] = 0u;
             auto iter = dictionary.buffers[1].begin();
-            const auto offset = [&dictionary](){ return dictionary.buffers[0].data<std::int64_t>(); };
+            const auto offset = [&dictionary]()
+            {
+                return dictionary.buffers[0].data<std::int64_t>();
+            };
 
             for (size_t i = 0; i < words.size(); ++i)
             {
-                offset()[i+1] = offset()[i] + words[i].size();
+                offset()[i + 1] = offset()[i] + words[i].size();
                 std::ranges::copy(words[i], iter);
                 iter += words[i].size();
                 dictionary.bitmap.set(i, true);
@@ -73,14 +82,7 @@ namespace sparrow
             return dictionary;
         }
 
-        static constexpr std::array<std::string_view, 5> words = 
-        {
-            "you",
-            "are",
-            "not",
-            "prepared",
-            "null"
-        };
+        static constexpr std::array<std::string_view, 5> words = {"you", "are", "not", "prepared", "null"};
 
         array_data m_data;
         using sub_layout_type = variable_size_binary_layout<std::string, std::string_view, std::string_view>;
@@ -89,7 +91,6 @@ namespace sparrow
 
     TEST_SUITE("dictionary_encoded_layout")
     {
-
         TEST_CASE_FIXTURE(dictionary_encoded_fixture, "constructors")
         {
             CHECK(m_data.buffers.size() == 1);

--- a/test/test_dynamic_bitset.cpp
+++ b/test/test_dynamic_bitset.cpp
@@ -12,12 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "doctest/doctest.h"
-
 #include <cstdint>
 #include <iostream>
 
 #include "sparrow/dynamic_bitset.hpp"
+
+#include "doctest/doctest.h"
 
 namespace sparrow
 {
@@ -26,11 +26,11 @@ namespace sparrow
         bitmap_fixture()
         {
             p_buffer = new std::uint8_t[m_block_count];
-            p_buffer[0] = 38; // 00100110
-            p_buffer[1] = 85; // 01010101
-            p_buffer[2] = 53; // 00110101
-            p_buffer[3] = 7;  // 00000111
-            m_null_count = 15; // Last 3 bits of buffer[3] are unused
+            p_buffer[0] = 38;   // 00100110
+            p_buffer[1] = 85;   // 01010101
+            p_buffer[2] = 53;   // 00110101
+            p_buffer[3] = 7;    // 00000111
+            m_null_count = 15;  // Last 3 bits of buffer[3] are unused
         }
 
         std::uint8_t* p_buffer;
@@ -38,7 +38,7 @@ namespace sparrow
         std::size_t m_size = 29;
         std::size_t m_null_count;
     };
-    
+
     TEST_SUITE("dynamic_bitset")
     {
         using bitmap = dynamic_bitset<std::uint8_t>;
@@ -73,7 +73,7 @@ namespace sparrow
         {
             bitmap b(p_buffer, m_size);
             CHECK_EQ(b.data(), p_buffer);
-            
+
             const bitmap& b2 = b;
             CHECK_EQ(b2.data(), p_buffer);
         }
@@ -96,9 +96,9 @@ namespace sparrow
             buf[0] = 37;
             buf[1] = 2;
             bitmap b3(buf, expected_block_count * 8);
-            
+
             b2 = b3;
-            CHECK_EQ(b2.size() , b3.size());
+            CHECK_EQ(b2.size(), b3.size());
             CHECK_EQ(b2.null_count(), b3.null_count());
             CHECK_NE(b2.data(), b3.data());
             for (size_t i = 0; i < expected_block_count; ++i)
@@ -210,7 +210,7 @@ namespace sparrow
         TEST_CASE_FIXTURE(bitmap_fixture, "iterator")
         {
             // Does not work because the reference is not bool&
-            //static_assert(std::random_access_iterator<typename bitmap::iterator>);
+            // static_assert(std::random_access_iterator<typename bitmap::iterator>);
             static_assert(std::random_access_iterator<typename bitmap::const_iterator>);
 
             bitmap b(p_buffer, m_size);
@@ -263,7 +263,7 @@ namespace sparrow
 
         TEST_CASE_FIXTURE(bitmap_fixture, "bitset_reference")
         {
-            //as a reminder: p_buffer[0] = 38; // 00100110
+            // as a reminder: p_buffer[0] = 38; // 00100110
             bitmap b(p_buffer, m_size);
             auto iter = b.begin();
             *iter = true;
@@ -292,4 +292,3 @@ namespace sparrow
         }
     }
 }
-

--- a/test/test_fixed_size_layout.cpp
+++ b/test/test_fixed_size_layout.cpp
@@ -14,9 +14,9 @@
 #include <iostream>
 #include <numeric>
 
-#include "doctest/doctest.h"
-
 #include "sparrow/fixed_size_layout.hpp"
+
+#include "doctest/doctest.h"
 
 namespace sparrow
 {
@@ -127,7 +127,9 @@ namespace sparrow
             for (std::size_t i = 0; i < lt.size(); ++i)
             {
                 if (i % 2 != 0)
+                {
                     lt[i] = std::nullopt;
+                }
             }
 
             layout_test_type::const_bitmap_iterator citer = lt_bitmap.begin();
@@ -152,14 +154,15 @@ namespace sparrow
 
             CHECK_EQ(it, end);
 
-            for (auto v: lt)
+            for (auto v : lt)
+            {
                 CHECK(v.has_value());
+            }
 
             array_data ad_empty = make_test_array_data(0, 0);
             layout_test_type lt_empty(ad_empty);
             CHECK_EQ(lt_empty.begin(), lt_empty.end());
         }
-
     }
 
 }

--- a/test/test_iterator.cpp
+++ b/test/test_iterator.cpp
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "doctest/doctest.h"
-
 #include <array>
 #include <cstddef>
 #include <numeric>
@@ -21,11 +19,12 @@
 #include "sparrow/buffer.hpp"
 #include "sparrow/iterator.hpp"
 
+#include "doctest/doctest.h"
+
 namespace sparrow
 {
 
-    class test_iterator:
-        public iterator_base<test_iterator, int, std::contiguous_iterator_tag>
+    class test_iterator : public iterator_base<test_iterator, int, std::contiguous_iterator_tag>
     {
     public:
 
@@ -247,7 +246,7 @@ namespace sparrow
     {
         TEST_CASE("make_pointer_iterator")
         {
-            std::array<int, 3> a = { 2, 4, 6 };
+            std::array<int, 3> a = {2, 4, 6};
             auto iter = make_pointer_iterator(&a[0]);
             CHECK_EQ(*iter, a[0]);
             ++iter;
@@ -258,7 +257,7 @@ namespace sparrow
 
         TEST_CASE("const conversion")
         {
-            std::array<int, 3> a = { 2, 4, 6 };
+            std::array<int, 3> a = {2, 4, 6};
             using iterator = pointer_iterator<int*>;
             using const_iterator = pointer_iterator<const int*>;
 

--- a/test/test_mpl.cpp
+++ b/test/test_mpl.cpp
@@ -12,28 +12,28 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <sparrow/mp_utils.hpp>
-
 #include <vector>
+
+#include <sparrow/mp_utils.hpp>
 
 namespace sparrow
 {
 
-/////////////////////////////////////////////////////////////////////////////
-// Type predicates
+    /////////////////////////////////////////////////////////////////////////////
+    // Type predicates
 
 
     static_assert(mpl::type_wrapper<std::type_identity_t, int>);
     static_assert(mpl::type_wrapper<mpl::typelist, int>);
 
     static_assert(mpl::ct_type_predicate<std::is_integral, float>);
-    static_assert(mpl::callable_type_predicate< mpl::predicate::same_as<int>, float >);
+    static_assert(mpl::callable_type_predicate<mpl::predicate::same_as<int>, float>);
 
     static constexpr mpl::ct_type_predicate_to_callable<std::is_integral> object_tpredicate;
     static_assert(object_tpredicate(mpl::typelist<int>{}));
 
 
-    static_assert(mpl::callable_type_predicate< mpl::ct_type_predicate_to_callable<std::is_integral>, int >);
+    static_assert(mpl::callable_type_predicate<mpl::ct_type_predicate_to_callable<std::is_integral>, int>);
     static constexpr auto is_integral = mpl::as_predicate<std::is_integral>();
     static_assert(mpl::callable_type_predicate<decltype(is_integral), int>);
 
@@ -41,20 +41,24 @@ namespace sparrow
     static constexpr auto some_types = mpl::typelist<int, float>{};
     static constexpr auto same_as_int = mpl::predicate::same_as<int>{};
     static_assert(same_as_int(mpl::typelist<int>{}));
-    static_assert( mpl::any_of(some_types, same_as_int) == true);
+    static_assert(mpl::any_of(some_types, same_as_int) == true);
     static_assert(mpl::all_of(some_types, same_as_int) == false);
 
-//////////////////////////////////////////////////////////////////////////////
-// Type-list
+    //////////////////////////////////////////////////////////////////////////////
+    // Type-list
 
-    using test_list = mpl::typelist< int, char >;
-    struct not_a_list { };
+    using test_list = mpl::typelist<int, char>;
+
+    struct not_a_list
+    {
+    };
+
     static_assert(mpl::any_typelist<test_list>);
     static_assert(not mpl::any_typelist<not_a_list>);
     static_assert(mpl::size(test_list{}) == 2);
 
-//////////////////////////////////////////////////////////////////////////////
-// Algorithm
+    //////////////////////////////////////////////////////////////////////////////
+    // Algorithm
 
     // any_of
     static_assert(mpl::any_of(test_list{}, mpl::predicate::same_as<int>{}));
@@ -67,7 +71,9 @@ namespace sparrow
 
     // all_of
     static_assert(mpl::all_of(mpl::typelist<int, int, int, int, int>{}, mpl::predicate::same_as<int>{}));
-    static_assert(not mpl::all_of(mpl::typelist<float, int, float, int, float>{}, mpl::predicate::same_as<float>{}));
+    static_assert(
+        not mpl::all_of(mpl::typelist<float, int, float, int, float>{}, mpl::predicate::same_as<float>{})
+    );
     static_assert(mpl::all_of(mpl::typelist<>{}, mpl::predicate::same_as<int>{}));
     static_assert(mpl::all_of(test_list{}, mpl::as_predicate<std::is_integral>()));
     static_assert(mpl::all_of<std::is_integral>(test_list{}));
@@ -94,8 +100,6 @@ namespace sparrow
     static_assert(mpl::contains<char>(test_list{}));
     static_assert(not mpl::contains<float>(test_list{}));
     static_assert(not mpl::contains<double>(test_list{}));
-
-
 
 
 }

--- a/test/test_traits.cpp
+++ b/test/test_traits.cpp
@@ -17,9 +17,11 @@
 /////////////////////////////////////////////////////////////////////////////////////////
 // Opt-in support for custom C++ representations of arrow data types.
 
-struct MyDataType{};
+struct MyDataType
+{
+};
 
-template<>
+template <>
 struct sparrow::arrow_traits<MyDataType>
 {
     static constexpr data_type type_id = sparrow::data_type::INT32;
@@ -27,9 +29,8 @@ struct sparrow::arrow_traits<MyDataType>
     using default_layout = sparrow::fixed_size_layout<MyDataType>;
 };
 
-
-static_assert( sparrow::is_arrow_traits< sparrow::arrow_traits<MyDataType> > );
-static_assert( sparrow::any_arrow_type< MyDataType > );
+static_assert(sparrow::is_arrow_traits<sparrow::arrow_traits<MyDataType>>);
+static_assert(sparrow::any_arrow_type<MyDataType>);
 
 //////////////////////////////////////////////////////////////////////////////////////////
 // Base arrow types representations support tests and concept checking.

--- a/test/test_variable_size_binary_layout.cpp
+++ b/test/test_variable_size_binary_layout.cpp
@@ -12,15 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "doctest/doctest.h"
-
+#include <iostream>
 #include <numeric>
 #include <string_view>
 
 #include "sparrow/array_data.hpp"
 #include "sparrow/variable_size_binary_layout.hpp"
 
-#include <iostream>
+#include "doctest/doctest.h"
 
 namespace sparrow
 {
@@ -32,13 +31,19 @@ namespace sparrow
             m_data.buffers.resize(2);
             m_data.buffers[0].resize(sizeof(std::int64_t) * (nb_words + 1));
             m_data.buffers[1].resize(std::accumulate(
-                words, words + nb_words, 0u, [](std::size_t res, const auto& s) { return res + s.size(); }
+                words,
+                words + nb_words,
+                0u,
+                [](std::size_t res, const auto& s)
+                {
+                    return res + s.size();
+                }
             ));
             m_data.buffers[0].data<std::int64_t>()[0] = 0u;
             auto iter = m_data.buffers[1].begin();
             for (size_t i = 0; i < nb_words; ++i)
             {
-                offset()[i+1] = offset()[i] + words[i].size();
+                offset()[i + 1] = offset()[i] + words[i].size();
                 std::copy(words[i].cbegin(), words[i].cend(), iter);
                 iter += words[i].size();
                 m_data.bitmap.set(i, true);
@@ -50,18 +55,12 @@ namespace sparrow
         }
 
         static constexpr size_t nb_words = 4u;
-        static constexpr std::string_view words[nb_words] = 
-        {
-            "you",
-            "are",
-            "not",
-            "prepared"
-        };
+        static constexpr std::string_view words[nb_words] = {"you", "are", "not", "prepared"};
 
         array_data m_data;
         // TODO: replace R = std::string_view with specific reference proxy
         using layout_type = variable_size_binary_layout<std::string, std::string_view, std::string_view>;
-    
+
     private:
 
         std::int64_t* offset()


### PR DESCRIPTION
Fix #42
There is no warning in the checks as we only check modified files.
You can test the rules with https://clang-format-configurator.site/
There are 2 cmake targets: a dry run and an auto fix which run over all the files.