### PR TITLE
Implemented pointer_iterator

### DIFF
--- a/include/sparrow/buffer.hpp
+++ b/include/sparrow/buffer.hpp
@@ -24,49 +24,6 @@
 
 namespace sparrow
 {
-    template <class T, bool is_const>
-    class buffer_iterator
-        : public iterator_base
-          <
-              buffer_iterator<T, is_const>,
-              mpl::constify_t<T, is_const>,
-              std::contiguous_iterator_tag
-          >
-    {
-    public:
-
-        using self_type = buffer_iterator<T, is_const>;
-        using base_type = iterator_base
-        <
-            self_type,
-            mpl::constify_t<T, is_const>,
-            std::contiguous_iterator_tag
-        >;
-        using pointer = typename base_type::pointer;
-
-        // Required so that std::ranges::end(b) is
-        // valid when b is a buffer or buffer_view
-        buffer_iterator() = default;
-        explicit buffer_iterator(pointer p);
-
-    private:
-
-        using reference = typename base_type::reference;
-        using difference_type = typename base_type::difference_type;
-
-        reference dereference() const;
-        void increment();
-        void decrement();
-        void advance(difference_type n);
-        difference_type distance_to(const self_type& rhs) const;
-        bool equal(const self_type& rhs) const;
-        bool less_than(const self_type& rhs) const;
-
-        pointer m_pointer = nullptr;
-
-        friend class iterator_access;
-    };
-
     /**
      * @class buffer_base
      * @brief Base class for buffer and buffer_view
@@ -90,8 +47,8 @@ namespace sparrow
         using size_type = std::size_t;
         using difference_type = std::ptrdiff_t;
 
-        using iterator = buffer_iterator<T, false>;
-        using const_iterator = buffer_iterator<T, true>;
+        using iterator = pointer_iterator<pointer>;
+        using const_iterator = pointer_iterator<const_pointer>;
         using reverse_iterator = std::reverse_iterator<iterator>;
         using const_reverse_iterator = std::reverse_iterator<const_iterator>;
 
@@ -215,58 +172,6 @@ namespace sparrow
         buffer_view(buffer_view&&) = default;
         buffer_view& operator=(buffer_view&&) = default;
     };
-
-    /**********************************
-     * buffer_iterator implementation *
-     **********************************/
-
-    template <class T, bool is_const>
-    buffer_iterator<T, is_const>::buffer_iterator(pointer p)
-        : m_pointer(p)
-    {
-    }
-
-    template <class T, bool is_const>
-    auto buffer_iterator<T, is_const>::dereference() const -> reference
-    {
-        return *m_pointer;
-    }
-
-    template <class T, bool is_const>
-    void buffer_iterator<T, is_const>::increment()
-    {
-        ++m_pointer;
-    }
-
-    template <class T, bool is_const>
-    void buffer_iterator<T, is_const>::decrement()
-    {
-        --m_pointer;
-    }
-
-    template <class T, bool is_const>
-    void buffer_iterator<T, is_const>::advance(difference_type n)
-    {
-        m_pointer += n;
-    }
-
-    template <class T, bool is_const>
-    auto buffer_iterator<T, is_const>::distance_to(const self_type& rhs) const -> difference_type
-    {
-        return rhs.m_pointer - m_pointer;
-    }
-
-    template <class T, bool is_const>
-    bool buffer_iterator<T, is_const>::equal(const self_type& rhs) const
-    {
-        return m_pointer == rhs.m_pointer;
-    }
-
-    template <class T, bool is_const>
-    bool buffer_iterator<T, is_const>::less_than(const self_type& rhs) const
-    {
-        return m_pointer < rhs.m_pointer;
-    }
 
     /******************************
      * buffer_base implementation *

--- a/include/sparrow/fixed_size_layout.hpp
+++ b/include/sparrow/fixed_size_layout.hpp
@@ -27,54 +27,6 @@
 namespace sparrow
 {
     /**
-     * An iterator for `fixed_size_layout` operating on contiguous data only.
-     *
-     * @tparam T The type of the elements in the layout's data buffer.
-     * @tparam is_const A boolean indicating whether the iterator is const.
-     *
-     */
-    template <class T, bool is_const>
-    class fixed_size_layout_value_iterator
-        : public iterator_base
-        <
-            fixed_size_layout_value_iterator<T, is_const>,
-            mpl::constify_t<T, is_const>,
-            std::contiguous_iterator_tag
-        >
-    {
-    public:
-
-        using self_type = fixed_size_layout_value_iterator<T, is_const>;
-        using base_type = iterator_base
-        <
-            self_type,
-            mpl::constify_t<T, is_const>,
-            std::contiguous_iterator_tag
-        >;
-        using pointer = typename base_type::pointer;
-
-        fixed_size_layout_value_iterator() = default;
-        explicit fixed_size_layout_value_iterator(pointer p);
-
-    private:
-        using reference = typename base_type::reference;
-        using difference_type = typename base_type::difference_type;
-        using size_type = std::size_t;
-
-        reference dereference() const;
-        void increment();
-        void decrement();
-        void advance(difference_type n);
-        difference_type distance_to(const self_type& hs) const;
-        bool equal(const self_type& rhs) const;
-        bool less_than(const self_type& rhs) const;
-
-        pointer m_pointer = nullptr;
-
-        friend class iterator_access;
-    };
-
-    /**
      * A contiguous layout for fixed size types.
      *
      * This class provides a contiguous layout for fixed size types, such as `uint8_t`, `int32_t`, etc.
@@ -106,10 +58,10 @@ namespace sparrow
         using difference_type = std::ptrdiff_t;
 
         using const_bitmap_iterator = array_data::bitmap_type::const_iterator;
-        using const_value_iterator = fixed_size_layout_value_iterator<T, true>;
+        using const_value_iterator = pointer_iterator<const_pointer>;
 
         using bitmap_iterator = array_data::bitmap_type::iterator;
-        using value_iterator = fixed_size_layout_value_iterator<T, false>;
+        using value_iterator = pointer_iterator<pointer>;
 
         using const_bitmap_range = std::ranges::subrange<const_bitmap_iterator>;
         using const_value_range = std::ranges::subrange<const_value_iterator>;
@@ -160,58 +112,6 @@ namespace sparrow
         friend class reference_proxy<fixed_size_layout>;
         friend class const_reference_proxy<fixed_size_layout>;
     };
-
-    /***************************************************
-     * fixed_size_layout_value_iterator implementation *
-     **************************************************/
-
-    template <class T, bool is_const>
-    fixed_size_layout_value_iterator<T, is_const>::fixed_size_layout_value_iterator(pointer pointer)
-        : m_pointer(pointer)
-    {
-    }
-
-    template <class T, bool is_const>
-    auto fixed_size_layout_value_iterator<T, is_const>::dereference() const -> reference
-    {
-        return *m_pointer;
-    }
-
-    template <class T, bool is_const>
-    void fixed_size_layout_value_iterator<T, is_const>::increment()
-    {
-        ++m_pointer;
-    }
-
-    template <class T, bool is_const>
-    void fixed_size_layout_value_iterator<T, is_const>::decrement()
-    {
-        --m_pointer;
-    }
-
-    template <class T, bool is_const>
-    void fixed_size_layout_value_iterator<T, is_const>::advance(difference_type n)
-    {
-        m_pointer += n;
-    }
-
-    template <class T, bool is_const>
-    auto fixed_size_layout_value_iterator<T, is_const>::distance_to(const self_type& rhs) const -> difference_type
-    {
-        return rhs.m_pointer - m_pointer;
-    }
-
-    template <class T, bool is_const>
-    bool fixed_size_layout_value_iterator<T, is_const>::equal(const self_type& rhs) const
-    {
-        return rhs.m_pointer == m_pointer;
-    }
-
-    template <class T, bool is_const>
-    bool fixed_size_layout_value_iterator<T, is_const>::less_than(const self_type& rhs) const
-    {
-        return m_pointer < rhs.m_pointer;
-    }
 
     /************************************
      * fixed_size_layout implementation *

--- a/include/sparrow/iterator.hpp
+++ b/include/sparrow/iterator.hpp
@@ -401,4 +401,88 @@ namespace sparrow
         : public iterator_root_base<Derived, Element, IteratorConcept, Reference, Difference>
     {
     };
+
+    /*
+     * @class pointer_iterator
+     * @brief iterator adaptor for pointers
+     *
+     * pointer_iterator gives an iterator API to a pointer.
+     * @tparam T the pointer to adapt
+     */
+    template <class T>
+    class pointer_iterator;
+
+    template <class T>
+    class pointer_iterator<T*> 
+        : public iterator_base<pointer_iterator<T*>, T, std::contiguous_iterator_tag>
+    {
+    public:
+        
+        using self_type = pointer_iterator<T*>;
+        using base_type = iterator_base<self_type, T, std::contiguous_iterator_tag>;
+        using pointer = typename base_type::pointer;
+        
+        pointer_iterator() = default;
+        explicit pointer_iterator(pointer p)
+            : p_iter(p)
+        {
+        }
+
+        template <class Iter>
+        requires std::same_as<Iter, std::remove_const_t<T>>
+        pointer_iterator(const Iter& iter)
+            : p_iter(iter.base())
+        {
+        }
+
+        const pointer& base() const
+        {
+            return p_iter;
+        }
+
+    private:
+
+        using reference = typename base_type::reference;
+        using difference_type = typename base_type::difference_type;
+
+        reference dereference() const
+        {
+            return *p_iter;
+        }
+
+        void increment()
+        {
+            ++p_iter;
+        }
+
+        void decrement()
+        {
+            --p_iter;
+        }
+
+        void advance(difference_type n)
+        {
+            p_iter += n;
+        }
+
+        difference_type distance_to(const self_type& rhs) const
+        {
+            return rhs.p_iter - p_iter;
+        }
+
+        bool equal(const self_type& rhs) const
+        {
+            return p_iter == rhs.p_iter;
+        }
+
+        bool less_than(const self_type& rhs) const
+        {
+            return p_iter < rhs.p_iter;
+        }
+        
+        pointer p_iter = nullptr;
+
+        friend class iterator_access;
+    };
+
 }


### PR DESCRIPTION
The current `buffer_iterator` and `fixed_size_layout_value_iterator` are very similar, they adapt a pointer to make it an iterator. More classes to come will have to do the same. This PR captures the common implementation in the `pointer_iterator` class, to reduce code duplication.