### PR TITLE
Contracts header with assertion macros specific to Sparrow

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -62,6 +62,7 @@ set(SPARROW_HEADERS
     ${SPARROW_INCLUDE_DIR}/sparrow/allocator.hpp
     ${SPARROW_INCLUDE_DIR}/sparrow/array_data.hpp
     ${SPARROW_INCLUDE_DIR}/sparrow/buffer.hpp
+    ${SPARROW_INCLUDE_DIR}/sparrow/contracts.hpp
     ${SPARROW_INCLUDE_DIR}/sparrow/data_type.hpp
     ${SPARROW_INCLUDE_DIR}/sparrow/data_traits.hpp
     ${SPARROW_INCLUDE_DIR}/sparrow/dynamic_bitset.hpp

--- a/include/sparrow/array_data.hpp
+++ b/include/sparrow/array_data.hpp
@@ -14,11 +14,11 @@
 
 #pragma once
 
-#include <cassert>
 #include <compare>
 #include <optional>
 #include <vector>
 
+#include "sparrow/contracts.hpp"
 #include "sparrow/buffer.hpp"
 #include "sparrow/data_type.hpp"
 #include "sparrow/dynamic_bitset.hpp"
@@ -327,7 +327,7 @@ namespace sparrow
     template <class L>
     auto const_reference_proxy<L>::value() const -> const_reference
     {
-        assert(has_value());
+        SPARROW_ASSERT_TRUE(has_value());
         return m_val_ref;
     }
 
@@ -357,14 +357,14 @@ namespace sparrow
     template <class L>
     auto reference_proxy<L>::value() -> value_type&
     {
-        assert(has_value());
+        SPARROW_ASSERT_TRUE(has_value());
         return m_val_ref;
     }
 
     template <class L>
     auto reference_proxy<L>::value() const -> const value_type&
     {
-        assert(has_value());
+        SPARROW_ASSERT_TRUE(has_value());
         return m_val_ref;
     }
 

--- a/include/sparrow/buffer.hpp
+++ b/include/sparrow/buffer.hpp
@@ -220,28 +220,28 @@ namespace sparrow
     template <class T>
     auto buffer_base<T>::front() -> reference
     {
-        SPARROW_ASSERT_TRUE(!empty());
+        SPARROW_ASSERT_FALSE(empty());
         return data()[0];
     }
 
     template <class T>
     auto buffer_base<T>::front() const -> const_reference
     {
-        SPARROW_ASSERT_TRUE(!empty());
+        SPARROW_ASSERT_FALSE(empty());
         return data()[0];
     }
 
     template <class T>
     auto buffer_base<T>::back() -> reference
     {
-        SPARROW_ASSERT_TRUE(!empty());
+        SPARROW_ASSERT_FALSE(empty());
         return data()[m_size - 1];
     }
 
     template <class T>
     auto buffer_base<T>::back() const -> const_reference
     {
-        SPARROW_ASSERT_TRUE(!empty());
+        SPARROW_ASSERT_FALSE(empty());
         return data()[m_size - 1];
     }
 

--- a/include/sparrow/buffer.hpp
+++ b/include/sparrow/buffer.hpp
@@ -15,10 +15,10 @@
 #pragma once
 
 #include <algorithm>
-#include <cassert>
 #include <concepts>
 #include <cstdint>
 
+#include "sparrow/contracts.hpp"
 #include "sparrow/iterator.hpp"
 #include "sparrow/mp_utils.hpp"
 
@@ -206,42 +206,42 @@ namespace sparrow
     template <class T>
     auto buffer_base<T>::operator[](size_type pos) -> reference
     {
-        assert(pos < size());
+        SPARROW_ASSERT_TRUE(pos < size());
         return data()[pos];
     }
 
     template <class T>
     auto buffer_base<T>::operator[](size_type pos) const -> const_reference
     {
-        assert(pos < size());
+        SPARROW_ASSERT_TRUE(pos < size());
         return data()[pos];
     }
 
     template <class T>
     auto buffer_base<T>::front() -> reference
     {
-        assert(!empty());
+        SPARROW_ASSERT_TRUE(!empty());
         return data()[0];
     }
 
     template <class T>
     auto buffer_base<T>::front() const -> const_reference
     {
-        assert(!empty());
+        SPARROW_ASSERT_TRUE(!empty());
         return data()[0];
     }
 
     template <class T>
     auto buffer_base<T>::back() -> reference
     {
-        assert(!empty());
+        SPARROW_ASSERT_TRUE(!empty());
         return data()[m_size - 1];
     }
 
     template <class T>
     auto buffer_base<T>::back() const -> const_reference
     {
-        assert(!empty());
+        SPARROW_ASSERT_TRUE(!empty());
         return data()[m_size - 1];
     }
 

--- a/include/sparrow/contracts.hpp
+++ b/include/sparrow/contracts.hpp
@@ -1,0 +1,144 @@
+// Copyright 2024 Man Group Operations Limited
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// NOTE: This is based upon v0.3.0 of NoContracts library https://github.com/Klaim/nocontracts/tree/0ffc183f7527213e3f0a57b8dae9befa7c0ca02c
+// Modifications: renamed macros
+
+#pragma once
+#include <cstdio>
+#include <csignal>
+
+
+///////////////////////////////////////////////////////////////////
+// Possible bits used to compose the behavior:
+
+// if not specified by the user but available, use std::print
+#if not defined(SPARROW_CONTRACTS_USE_STD_PRINT) and not defined(SPARROW_CONTRACTS_USE_STD_FORMAT)
+# if __cplusplus >= 202002L
+#  include <version>
+#  ifdef __cpp_lib_print
+#   define SPARROW_CONTRACTS_USE_STD_PRINT 1
+#  endif
+# endif
+#else
+// The option is defined, but is it supported? If not we fail.
+#  if defined(SPARROW_CONTRACTS_USE_STD_PRINT) and not defined(__cpp_lib_print)
+#    error "std::print usage is requested but not available"
+#  endif
+#endif
+
+// if not specified by the user but available and std::print is not already forced, use std::format
+#if not defined(SPARROW_CONTRACTS_USE_STD_FORMAT) and not defined(SPARROW_CONTRACTS_USE_STD_PRINT)
+# if __cplusplus >= 202002L
+#  include <version>
+#  ifdef __cpp_lib_format
+#   define SPARROW_CONTRACTS_USE_STD_FORMAT 1
+#  endif
+# endif
+// The option is defined, but is it supported? If not we fail.
+#  if defined(SPARROW_CONTRACTS_USE_STD_FORMAT) and not defined(__cpp_lib_format)
+#    error "std::format usage is requested but not available"
+#  endif
+#endif
+
+// user specified to use neither std::format nor std::print, but C's formatting
+#if defined(SPARROW_CONTRACTS_USE_CFORMAT) && SPARROW_CONTRACTS_USE_CFORMAT == 1
+# ifdef SPARROW_CONTRACTS_USE_STD_FORMAT
+#   undef SPARROW_CONTRACTS_USE_STD_FORMAT
+# endif
+# ifdef SPARROW_CONTRACTS_USE_STD_PRINT
+#   undef SPARROW_CONTRACTS_USE_STD_PRINT
+# endif
+#endif
+
+#ifndef SPARROW_CONTRACTS_LOG_FAILURE
+# if defined(SPARROW_CONTRACTS_USE_STD_PRINT) && SPARROW_CONTRACTS_USE_STD_PRINT == 1
+#   include <print>
+#   include <cstdio>
+#   define SPARROW_CONTRACTS_LOG_FAILURE( expr__, message__ ) \
+      ::std::print(stderr, "Assertion Failed ({}:{}): {} - ({} is wrong)\n", __FILE__, __LINE__, message__, #expr__ )
+# elif defined(SPARROW_CONTRACTS_USE_STD_FORMAT) && SPARROW_CONTRACTS_USE_STD_FORMAT == 1
+#   include <format>
+#   include <cstdio>
+#   define SPARROW_CONTRACTS_LOG_FAILURE( expr__, message__ ) \
+      ::fprintf(stderr, ::std::format("Assertion Failed ({}:{}): {} - ({} is wrong)\n", __FILE__, __LINE__, message__, #expr__ ).c_str())
+# else
+#   include <cstdlib>
+#   include <cstdio>
+#   define SPARROW_CONTRACTS_LOG_FAILURE( expr__, message__ ) \
+      ::fprintf(stderr, "Assertion Failed (%s:%i): %s - (%s is wrong)\n", __FILE__, __LINE__, message__, #expr__ )
+# endif
+#endif
+
+#ifndef SPARROW_CONTRACTS_ABORT
+# define SPARROW_CONTRACTS_ABORT() \
+    std::abort()
+#endif
+
+// User specifies to just continue instead of abort on failure.
+#if defined(SPARROW_CONTRACTS_CONTINUE_ON_FAILURE) and SPARROW_CONTRACTS_CONTINUE_ON_FAILURE == 1
+# undef SPARROW_CONTRACTS_ABORT
+# define SPARROW_CONTRACTS_ABORT
+#endif
+
+#ifndef SPARROW_CONTRACTS_DEBUGBREAK
+# ifdef _WIN32
+#   define SPARROW_CONTRACTS_DEBUGBREAK() __debugbreak();
+# else
+#   define SPARROW_CONTRACTS_DEBUGBREAK() std::raise(SIGTRAP);
+# endif
+#endif
+
+///////////////////////////////////////////////////////////////////
+// Default behavior:
+
+#define SPARROW_CONTRACTS_DEFAULT_CHECKS_ENABLED 1
+#define SPARROW_CONTRACTS_DEFAULT_ABORT_ON_FAILURE 1
+
+#define SPARROW_CONTRACTS_DEFAULT_ON_FAILURE( expr__, message__ ) \
+  SPARROW_CONTRACTS_LOG_FAILURE( expr__, message__ ); \
+  SPARROW_CONTRACTS_DEBUGBREAK(); \
+  SPARROW_CONTRACTS_ABORT();
+
+///////////////////////////////////////////////////////////////////
+// Apply Configuration:
+
+// If not override, use the default behavior.
+#ifndef SPARROW_CONTRACTS_CHECKS_ENABLED
+# define SPARROW_CONTRACTS_CHECKS_ENABLED SPARROW_CONTRACTS_DEFAULT_CHECKS_ENABLED
+#endif
+
+#if SPARROW_CONTRACTS_CHECKS_ENABLED == 1 // Behavior when contracts are enabled.
+
+# ifndef SPARROW_CONTRACTS_ON_FAILURE
+#   define SPARROW_CONTRACTS_ON_FAILURE( expr__, message__ ) \
+      SPARROW_CONTRACTS_DEFAULT_ON_FAILURE( expr__, message__ )
+# endif
+
+# ifndef SPARROW_ASSERT
+#   define SPARROW_ASSERT( expr__, message__ ) \
+      if(!( expr__ )) \
+      { SPARROW_CONTRACTS_ON_FAILURE( expr__, message__ ); }
+# endif
+
+# define SPARROW_ASSERT_TRUE( expr__ ) SPARROW_ASSERT( expr__, #expr__ )
+# define SPARROW_ASSERT_FALSE( expr__ ) SPARROW_ASSERT( !(expr__), "!("#expr__")" )
+
+# else // Do nothing otherwise.
+# define SPARROW_CONTRACTS_ON_FAILURE( expr__ )
+# define SPARROW_ASSERT( expr__, message__ )
+# define SPARROW_ASSERT_TRUE( expr__ )
+# define SPARROW_ASSERT_FALSE( expr__ )
+#endif
+

--- a/include/sparrow/dictionary_encoded_layout.hpp
+++ b/include/sparrow/dictionary_encoded_layout.hpp
@@ -14,6 +14,7 @@
 
 #pragma once
 
+#include "sparrow/contracts.hpp"
 #include "sparrow/array_data.hpp"
 #include "sparrow/fixed_size_layout.hpp"
 #include "sparrow/iterator.hpp"
@@ -203,7 +204,7 @@ namespace sparrow
     template <class IL, class SL, bool is_const>
     auto dictionary_value_iterator<IL, SL, is_const>::dereference() const -> reference
     {
-        assert(m_sub_layout_reference.has_value());
+        SPARROW_ASSERT_TRUE(m_sub_layout_reference.has_value());
         return (*m_sub_layout_reference).get()[*m_index_it];
     }
 
@@ -250,7 +251,7 @@ namespace sparrow
     template <std::integral T, class SL, layout_offset OT>
     dictionary_encoded_layout<T, SL, OT>::dictionary_encoded_layout(array_data& data)
     {
-        assert(data.dictionary);
+        SPARROW_ASSERT_TRUE(data.dictionary);
         m_sub_layout = std::make_unique<SL>(*data.dictionary);
         m_indexes_layout = std::make_unique<indexes_layout>(data);
     }
@@ -264,7 +265,7 @@ namespace sparrow
     template <std::integral T, class SL, layout_offset OT>
     auto dictionary_encoded_layout<T, SL, OT>::operator[](size_type i) const -> const_reference
     {
-        assert(i < size());
+        SPARROW_ASSERT_TRUE(i < size());
         const auto index = (*m_indexes_layout)[i];
         if (index.has_value())
         {

--- a/include/sparrow/dynamic_bitset.hpp
+++ b/include/sparrow/dynamic_bitset.hpp
@@ -14,11 +14,11 @@
 
 #pragma once
 
-#include <cassert>
 #include <climits>
 #include <concepts>
 #include <ranges>
 
+#include "sparrow/contracts.hpp"
 #include "sparrow/buffer.hpp"
 #include "sparrow/mp_utils.hpp"
 
@@ -313,28 +313,28 @@ namespace sparrow
     template <random_access_range B>
     auto dynamic_bitset_base<B>::operator[](size_type pos) -> reference
     {
-        assert(pos < size());
+        SPARROW_ASSERT_TRUE(pos < size());
         return reference(*this, m_buffer.data()[block_index(pos)], bit_mask(pos));
     }
 
     template <random_access_range B>
     bool dynamic_bitset_base<B>::operator[](size_type pos) const
     {
-        assert(pos < size());
+        SPARROW_ASSERT_TRUE(pos < size());
         return !m_null_count || m_buffer.data()[block_index(pos)] & bit_mask(pos);
     }
 
     template <random_access_range B>
     bool dynamic_bitset_base<B>::test(size_type pos) const
     {
-        assert(pos < size());
+        SPARROW_ASSERT_TRUE(pos < size());
         return !m_null_count || m_buffer.data()[block_index(pos)] & bit_mask(pos);
     }
 
     template <random_access_range B>
     void dynamic_bitset_base<B>::set(size_type pos, value_type value)
     {
-        assert(pos < size());
+        SPARROW_ASSERT_TRUE(pos < size());
         block_type& block = m_buffer.data()[block_index(pos)];
         const bool old_value = block & bit_mask(pos);
         if (value)
@@ -429,7 +429,7 @@ namespace sparrow
         , m_null_count(null_count)
     {
         zero_unused_bits();
-        assert(m_null_count == m_size - count_non_null());
+        SPARROW_ASSERT_TRUE(m_null_count == m_size - count_non_null());
     }
 
     template <random_access_range B>
@@ -697,7 +697,7 @@ namespace sparrow
         , p_block(block)
         , m_index(index)
     {
-        assert(m_index < bitset_type::s_bits_per_block);
+        SPARROW_ASSERT_TRUE(m_index < bitset_type::s_bits_per_block);
     }
 
     template <class B, bool is_const>
@@ -723,7 +723,7 @@ namespace sparrow
             ++p_block;
             m_index = 0u;
         }
-        assert(m_index < bitset_type::s_bits_per_block);
+        SPARROW_ASSERT_TRUE(m_index < bitset_type::s_bits_per_block);
     }
 
     template <class B, bool is_const>
@@ -739,7 +739,7 @@ namespace sparrow
         {
             --m_index;
         }
-        assert(m_index < bitset_type::s_bits_per_block);
+        SPARROW_ASSERT_TRUE(m_index < bitset_type::s_bits_per_block);
     }
 
     template <class B, bool is_const>
@@ -785,7 +785,7 @@ namespace sparrow
                 }
             }
         }
-        assert(m_index < bitset_type::s_bits_per_block);
+        SPARROW_ASSERT_TRUE(m_index < bitset_type::s_bits_per_block);
     }
 
     template <class B, bool is_const>

--- a/include/sparrow/fixed_size_layout.hpp
+++ b/include/sparrow/fixed_size_layout.hpp
@@ -15,10 +15,10 @@
 #pragma once
 
 #include <algorithm>
-#include <cassert>
 #include <concepts>
 #include <cstdint>
 
+#include "sparrow/contracts.hpp"
 #include "sparrow/array_data.hpp"
 #include "sparrow/buffer.hpp"
 #include "sparrow/dynamic_bitset.hpp"
@@ -131,42 +131,42 @@ namespace sparrow
         : m_data(data)
     {
         // We only require the presence of the bitmap and the first buffer.
-        assert(data_ref().buffers.size() > 0);
-        assert(data_ref().length == data_ref().bitmap.size());
+        SPARROW_ASSERT_TRUE(data_ref().buffers.size() > 0);
+        SPARROW_ASSERT_TRUE(data_ref().length == data_ref().bitmap.size());
     }
 
     template <class T>
     auto fixed_size_layout<T>::size() const -> size_type
     {
-        assert(data_ref().offset <= data_ref().length);
+        SPARROW_ASSERT_TRUE(data_ref().offset <= data_ref().length);
         return static_cast<size_type>(data_ref().length - data_ref().offset);
     }
 
     template <class T>
     auto fixed_size_layout<T>::value(size_type i) -> inner_reference
     {
-        assert(i < size());
+        SPARROW_ASSERT_TRUE(i < size());
         return data()[i + data_ref().offset];
     }
 
     template <class T>
     auto fixed_size_layout<T>::value(size_type i) const -> inner_const_reference
     {
-        assert(i < size());
+        SPARROW_ASSERT_TRUE(i < size());
         return data()[i + data_ref().offset];
     }
 
     template <class T>
     auto fixed_size_layout<T>::operator[](size_type i) -> reference
     {
-        assert(i < size());
+        SPARROW_ASSERT_TRUE(i < size());
         return reference(value(i), has_value(i));
     }
 
     template <class T>
     auto fixed_size_layout<T>::operator[](size_type i) const -> const_reference
     {
-        assert(i < size());
+        SPARROW_ASSERT_TRUE(i < size());
         return const_reference(value(i), has_value(i));
     }
 
@@ -209,14 +209,14 @@ namespace sparrow
     template <class T>
     auto fixed_size_layout<T>::has_value(size_type i) -> bitmap_reference
     {
-        assert(i < size());
+        SPARROW_ASSERT_TRUE(i < size());
         return data_ref().bitmap[i + data_ref().offset];
     }
 
     template <class T>
     auto fixed_size_layout<T>::has_value(size_type i) const -> bitmap_const_reference
     {
-        assert(i < size());
+        SPARROW_ASSERT_TRUE(i < size());
         return data_ref().bitmap[i + data_ref().offset];
     }
 
@@ -271,14 +271,14 @@ namespace sparrow
     template <class T>
     auto fixed_size_layout<T>::data() -> pointer
     {
-        assert(data_ref().buffers.size() > 0);
+        SPARROW_ASSERT_TRUE(data_ref().buffers.size() > 0);
         return data_ref().buffers[0].template data<inner_value_type>();
     }
 
     template <class T>
     auto fixed_size_layout<T>::data() const -> const_pointer
     {
-        assert(data_ref().buffers.size() > 0);
+        SPARROW_ASSERT_TRUE(data_ref().buffers.size() > 0);
         return data_ref().buffers[0].template data<inner_value_type>();
     }
 

--- a/include/sparrow/memory.hpp
+++ b/include/sparrow/memory.hpp
@@ -14,8 +14,9 @@
 
 #pragma once
 
-#include <cassert>
 #include <memory>
+
+#include "sparrow/contracts.hpp"
 
 namespace sparrow
 {
@@ -78,25 +79,25 @@ namespace sparrow
 
         T& operator*()
         {
-            assert(value_);
+            SPARROW_ASSERT_TRUE(value_);
             return *value_;
         }
 
         const T& operator*() const
         {
-            assert(value_);
+            SPARROW_ASSERT_TRUE(value_);
             return *value_;
         }
 
         T* operator->()
         {
-            assert(value_);
+            SPARROW_ASSERT_TRUE(value_);
             return &*value_;
         }
 
         const T* operator->() const
         {
-            assert(value_);
+            SPARROW_ASSERT_TRUE(value_);
             return &*value_;
         }
 

--- a/include/sparrow/variable_size_binary_layout.hpp
+++ b/include/sparrow/variable_size_binary_layout.hpp
@@ -326,21 +326,21 @@ namespace sparrow
     template <class T, class R, class CR, layout_offset OT>
     auto variable_size_binary_layout<T, R, CR, OT>::offset(size_type i) const -> const_offset_iterator
     {
-        SPARROW_ASSERT_TRUE(!data_ref().buffers.empty());
+        SPARROW_ASSERT_FALSE(data_ref().buffers.empty());
         return data_ref().buffers[0].template data<OT>() + data_ref().offset + i;
     }
 
     template <class T, class R, class CR, layout_offset OT>
     auto variable_size_binary_layout<T, R, CR, OT>::offset_end() const -> const_offset_iterator
     {
-        SPARROW_ASSERT_TRUE(!data_ref().buffers.empty());
+        SPARROW_ASSERT_FALSE(data_ref().buffers.empty());
         return data_ref().buffers[0].template data<OT>() + data_ref().length;
     }
 
     template <class T, class R, class CR, layout_offset OT>
     auto variable_size_binary_layout<T, R, CR, OT>::data(size_type i) const -> const_data_iterator
     {
-        SPARROW_ASSERT_TRUE(!data_ref().buffers.empty());
+        SPARROW_ASSERT_FALSE(data_ref().buffers.empty());
         return data_ref().buffers[1].template data<data_type>() + i;
     }
 

--- a/include/sparrow/variable_size_binary_layout.hpp
+++ b/include/sparrow/variable_size_binary_layout.hpp
@@ -17,6 +17,7 @@
 #include <functional>
 #include <ranges>
 
+#include "sparrow/contracts.hpp"
 #include "sparrow/array_data.hpp"
 #include "sparrow/iterator.hpp"
 #include "sparrow/mp_utils.hpp"
@@ -242,23 +243,23 @@ namespace sparrow
     variable_size_binary_layout<T, R, CR, OT>::variable_size_binary_layout(array_data& data)
         : m_data(data)
     {
-        assert(data_ref().buffers.size() == 2u);
+        SPARROW_ASSERT_TRUE(data_ref().buffers.size() == 2u);
         // TODO: templatize back and front in buffer and uncomment the following line
-        // assert(data_ref().buffers[0].size() == 0u || data_ref().buffers[0].back() ==
+        // SPARROW_ASSERT_TRUE(data_ref().buffers[0].size() == 0u || data_ref().buffers[0].back() ==
         // data_ref().buffers[1].size());
     }
 
     template <class T, class R, class CR, layout_offset OT>
     auto variable_size_binary_layout<T, R, CR, OT>::size() const -> size_type
     {
-        assert(data_ref().offset <= data_ref().length);
+        SPARROW_ASSERT_TRUE(data_ref().offset <= data_ref().length);
         return static_cast<size_type>(data_ref().length - data_ref().offset);
     }
 
     template <class T, class R, class CR, layout_offset OT>
     auto variable_size_binary_layout<T, R, CR, OT>::operator[](size_type i) const -> const_reference
     {
-        assert(i < size());
+        SPARROW_ASSERT_TRUE(i < size());
         return const_reference(value(i), has_value(i));
     }
 
@@ -325,21 +326,21 @@ namespace sparrow
     template <class T, class R, class CR, layout_offset OT>
     auto variable_size_binary_layout<T, R, CR, OT>::offset(size_type i) const -> const_offset_iterator
     {
-        assert(!data_ref().buffers.empty());
+        SPARROW_ASSERT_TRUE(!data_ref().buffers.empty());
         return data_ref().buffers[0].template data<OT>() + data_ref().offset + i;
     }
 
     template <class T, class R, class CR, layout_offset OT>
     auto variable_size_binary_layout<T, R, CR, OT>::offset_end() const -> const_offset_iterator
     {
-        assert(!data_ref().buffers.empty());
+        SPARROW_ASSERT_TRUE(!data_ref().buffers.empty());
         return data_ref().buffers[0].template data<OT>() + data_ref().length;
     }
 
     template <class T, class R, class CR, layout_offset OT>
     auto variable_size_binary_layout<T, R, CR, OT>::data(size_type i) const -> const_data_iterator
     {
-        assert(!data_ref().buffers.empty());
+        SPARROW_ASSERT_TRUE(!data_ref().buffers.empty());
         return data_ref().buffers[1].template data<data_type>() + i;
     }
 

--- a/test/test_array_data.cpp
+++ b/test/test_array_data.cpp
@@ -14,6 +14,7 @@
 
 #include <initializer_list>
 
+#include "sparrow/contracts.hpp"
 #include "sparrow/array_data.hpp"
 
 #include "doctest/doctest.h"
@@ -59,27 +60,27 @@ namespace sparrow
 
         reference operator[](size_type pos)
         {
-            assert(pos < m_bitmap.size());
-            assert(pos < m_data.size());
+            SPARROW_ASSERT_TRUE(pos < m_bitmap.size());
+            SPARROW_ASSERT_TRUE(pos < m_data.size());
             return reference(m_data[pos], m_bitmap[pos]);
         }
 
         const_reference operator[](size_type pos) const
         {
-            assert(pos < m_bitmap.size());
-            assert(pos < m_data.size());
+            SPARROW_ASSERT_TRUE(pos < m_bitmap.size());
+            SPARROW_ASSERT_TRUE(pos < m_data.size());
             return const_reference(m_data[pos], m_bitmap[pos]);
         }
 
         bool has_value(size_type pos) const
         {
-            assert(pos < m_bitmap.size());
+            SPARROW_ASSERT_TRUE(pos < m_bitmap.size());
             return m_bitmap[pos];
         }
 
         inner_const_reference value(size_type pos) const
         {
-            assert(pos < m_data.size());
+            SPARROW_ASSERT_TRUE(pos < m_data.size());
             return m_data[pos];
         }
 

--- a/test/test_variable_size_binary_layout.cpp
+++ b/test/test_variable_size_binary_layout.cpp
@@ -66,7 +66,7 @@ namespace sparrow
 
         std::int64_t* offset()
         {
-            SPARROW_ASSERT_TRUE(!m_data.buffers.empty());
+            SPARROW_ASSERT_FALSE(m_data.buffers.empty());
             return m_data.buffers[0].data<std::int64_t>();
         }
 

--- a/test/test_variable_size_binary_layout.cpp
+++ b/test/test_variable_size_binary_layout.cpp
@@ -16,6 +16,7 @@
 #include <numeric>
 #include <string_view>
 
+#include "sparrow/contracts.hpp"
 #include "sparrow/array_data.hpp"
 #include "sparrow/variable_size_binary_layout.hpp"
 
@@ -65,7 +66,7 @@ namespace sparrow
 
         std::int64_t* offset()
         {
-            assert(!m_data.buffers.empty());
+            SPARROW_ASSERT_TRUE(!m_data.buffers.empty());
             return m_data.buffers[0].data<std::int64_t>();
         }
 


### PR DESCRIPTION
This provides macros (extracted from my library NoContracts) for contract assertions checks, named with SPARROW_ so that control over enabling these assertions is let to the user.

The checks are enabled by default and all C `assert(...)` calls have been replaced.