### PR TITLE
Support clang++ from conda-forge

### DIFF
--- a/.github/workflows/osx.yml
+++ b/.github/workflows/osx.yml
@@ -13,7 +13,7 @@ defaults:
 jobs:
   build:
     runs-on: macos-${{ matrix.os }}
-    name: ${{ matrix.os }}-${{ matrix.config.name }}
+    name: ${{ matrix.os }}-${{ matrix.config.name }}-${{ matrix.compiler }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/osx.yml
+++ b/.github/workflows/osx.yml
@@ -22,13 +22,17 @@ jobs:
         config:
         - { name: Debug }
         - { name: Release }
+        compiler:
+        - clang
+        - apple-clang
 
     steps:
 
     - name: Checkout code
       uses: actions/checkout@v3
 
-    - name: Add specification clang++ in the conda environment specification
+    - name: Add specification of clang++ in the conda environment specification
+      if: matrix.compiler == 'clang'
       run: |
         echo "  - clangxx==17.0.6" >> environment-dev.yml
 
@@ -40,10 +44,17 @@ jobs:
         init-shell: bash
         cache-downloads: true
 
-    - name: Set environment variable to use clang++
+    - name: Use clang++ from conda-forge
+      if: matrix.compiler == 'clang'
       run: |
         echo "CXX=$CONDA_PREFIX/bin/clang++" >> $GITHUB_ENV
         echo "CMAKE_CXX_COMPILER=$CONDA_PREFIX/bin/clang++" >> $GITHUB_ENV
+
+    - name: Use Apple Clang (i.e. clang++ from Xcode)
+      if: matrix.compiler == 'apple-clang'
+      run: |
+        echo "CXX=/usr/bin/clang++" >> $GITHUB_ENV
+        echo "CMAKE_CXX_COMPILER=/usr/bin/clang++" >> $GITHUB_ENV
 
     - name: Configure using CMake
       run: cmake -Bbuild -DCMAKE_BUILD_TYPE:STRING=${{matrix.config.name}} -DCMAKE_INSTALL_PREFIX=$CONDA_PREFIX -DBUILD_TESTS=ON

--- a/.github/workflows/osx.yml
+++ b/.github/workflows/osx.yml
@@ -28,6 +28,10 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v3
 
+    - name: Add specification clang++ in the conda environment specification
+      run: |
+        echo "  - clangxx==17.0.6" >> environment-dev.yml
+
     - name: Set conda environment
       uses: mamba-org/setup-micromamba@main
       with:
@@ -35,6 +39,11 @@ jobs:
         environment-file: environment-dev.yml
         init-shell: bash
         cache-downloads: true
+
+    - name: Set environment variable to use clang++
+      run: |
+        echo "CXX=$CONDA_PREFIX/bin/clang++" >> $GITHUB_ENV
+        echo "CMAKE_CXX_COMPILER=$CONDA_PREFIX/bin/clang++" >> $GITHUB_ENV
 
     - name: Configure using CMake
       run: cmake -Bbuild -DCMAKE_BUILD_TYPE:STRING=${{matrix.config.name}} -DCMAKE_INSTALL_PREFIX=$CONDA_PREFIX -DBUILD_TESTS=ON

--- a/include/sparrow/algorithm.hpp
+++ b/include/sparrow/algorithm.hpp
@@ -21,7 +21,7 @@
 
 namespace sparrow
 {
-#if COMPILING_WITH_APPLE_CLANG
+#if COMPILING_WITH_APPLE_CLANG || USING_LIBCPP_PRE_17
 
     template <typename T>
     concept OrdCategory = std::same_as<T, std::strong_ordering> || std::same_as<T, std::weak_ordering>
@@ -71,7 +71,7 @@ namespace sparrow
     constexpr auto lexicographical_compare_three_way(const R1& range1, const R2& range2, Cmp comp)
         -> decltype(comp(*range1.cbegin(), *range2.cbegin()))
     {
-#if COMPILING_WITH_APPLE_CLANG
+#if COMPILING_WITH_APPLE_CLANG || USING_LIBCPP_PRE_17
         return lexicographical_compare_three_way_non_std(range1, range2, comp);
 #else
         return std::lexicographical_compare_three_way(
@@ -84,7 +84,7 @@ namespace sparrow
 #endif
     }
 
-#if COMPILING_WITH_APPLE_CLANG
+#if COMPILING_WITH_APPLE_CLANG || USING_LIBCPP_PRE_17
     struct compare_three_way
     {
         template <class T, class U>
@@ -109,7 +109,7 @@ namespace sparrow
         return lexicographical_compare_three_way<R1, R2>(
             r1,
             r2,
-#if COMPILING_WITH_APPLE_CLANG
+#if COMPILING_WITH_APPLE_CLANG || USING_LIBCPP_PRE_17
             compare_three_way {}
 #else
             std::compare_three_way{}

--- a/include/sparrow/config.hpp
+++ b/include/sparrow/config.hpp
@@ -20,6 +20,12 @@
 #define COMPILING_WITH_APPLE_CLANG 0
 #endif
 
+#if defined(_LIBCPP_VERSION) && _LIBCPP_VERSION < 170000
+#define USING_LIBCPP_PRE_17 1
+#else
+#define USING_LIBCPP_PRE_17 0
+#endif
+
 consteval bool is_apple_compiler()
 {
     return static_cast<bool>(COMPILING_WITH_APPLE_CLANG);


### PR DESCRIPTION
Even-though conda-forge's toolchain allows for using clang++ 18, libc++ 16 is the latest version available (see https://github.com/conda-forge/libcxx-feedstock/pull/131).

The `std::lexicographical_compare_three_way` has only been implemented in libc++ 17, so we use the vendored implementation when libc++ < 17 is used.