### PR TITLE
ci: Test GCC 12 on Linux

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -22,6 +22,7 @@ jobs:
         # - {compiler: clang, version: '16', config-flags: '-DCMAKE_CXX_FLAGS=-stdlib=libc++', stdlib: 'libc++-17' }
         - {compiler: clang, version: '17', config-flags: '', stdlib: 'libstdc++-13' }
         # - {compiler: clang, version: '17', config-flags: '-DCMAKE_CXX_FLAGS=-stdlib=libc++', stdlib: 'libc++-17' }
+        - {compiler: gcc, version: '12', config-flags: '' }
         - {compiler: gcc, version: '13', config-flags: '' }
 
         config:

--- a/include/sparrow/iterator.hpp
+++ b/include/sparrow/iterator.hpp
@@ -121,7 +121,8 @@ namespace sparrow
             it.advance(n);
         }
 
-#if _WIN32  // Workaround for access issue with msvc, when friend is involved
+// On MSVC and GCC < 13, those methods need to be public to be accessible by friend functions.
+#if _WIN32 || __GNUC__ < 13
 
     public:
 
@@ -143,11 +144,14 @@ namespace sparrow
         {
             return lhs.less_than(rhs);
         }
-#if _WIN32  // Workaround for access issue with msvc, when friend is involved
+
+// On MSVC and GCC < 13, those methods need to be public to be accessible by friend functions.
+#if _WIN32 || __GNUC__ < 13
 
     private:
 
 #endif
+
         template <class Derived, class E, class T, class R, class D>
         friend class iterator_root_base;
 


### PR DESCRIPTION
GCC / stdlibc++ 13 is relatively recent for most toolchains.

Let's also support GCC / stdlibc++ 12.