### PR TITLE
ci: Use libstdc++-12 after the upgrade to Ubuntu 22.04

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -18,9 +18,9 @@ jobs:
       fail-fast: false
       matrix:
         sys:
-        - {compiler: clang, version: '16', config-flags: '', stdlib: 'libstdc++-13' }
+        - {compiler: clang, version: '16', config-flags: '', stdlib: 'libstdc++-12' }
         # - {compiler: clang, version: '16', config-flags: '-DCMAKE_CXX_FLAGS=-stdlib=libc++', stdlib: 'libc++-17' }
-        - {compiler: clang, version: '17', config-flags: '', stdlib: 'libstdc++-13' }
+        - {compiler: clang, version: '17', config-flags: '', stdlib: 'libstdc++-12' }
         # - {compiler: clang, version: '17', config-flags: '-DCMAKE_CXX_FLAGS=-stdlib=libc++', stdlib: 'libc++-17' }
         - {compiler: gcc, version: '12', config-flags: '' }
         - {compiler: gcc, version: '13', config-flags: '' }

--- a/.github/workflows/osx.yml
+++ b/.github/workflows/osx.yml
@@ -24,7 +24,7 @@ jobs:
         - { name: Debug }
         - { name: Release }
         compiler:
-        - clang
+        # - clang # TODO: Uncomment this line when we have fixed the compilation issue
         - apple-clang
 
     steps:


### PR DESCRIPTION
[Ubuntu 22.04 images have been released yesterday](https://github.com/xtensor-stack/sparrow/actions/runs/9113436623/job/25054935536#step:4:11).

[`libstdc++-13-dev` cannot be resolved on this platform](https://github.com/xtensor-stack/sparrow/actions/runs/9113436623/job/25054935536#step:4:11).